### PR TITLE
Change device actions to an array

### DIFF
--- a/devices/schemas.yaml
+++ b/devices/schemas.yaml
@@ -29,9 +29,14 @@ Device:
       type: string
     actions:
       readOnly: true
-      type: object
+      type: array
       example:
-        _: "7fc1e84b"
+        - "TurnOn"
+        - "TurnOff"
+        - "TogglePower"
+        - "SetSpeed"
+        - "IncreaseSpeed"
+        - "DecreaseSpeed"
     properties:
       readOnly: true
       type: object


### PR DESCRIPTION
This array of actions is essentially a "shortcut", saving one hash comparison and potentially one request to `devices/<dev_id>/actions`.

This is already how the `devices/<dev_id>` endpoint is implemented, the change is just to make the docs reflect the implementation.