### PR TITLE
Change action_id number to action_name string

### DIFF
--- a/actions/paths.yaml
+++ b/actions/paths.yaml
@@ -3,10 +3,10 @@ ActionPath:
     $ref: ../actions/paths.yaml#/Put
   parameters:
   - in: path
-    name: action_id
+    name: action_name
     required: true
     schema:
-      type: number
+      type: string
   - in: path
     name: device_id
     required: true
@@ -32,7 +32,7 @@ Put:
       $ref: ../common/responses.yaml#/InternalServerError
   summary: Execute a device action
   description: |
-    The `action_id` is the name of the action from the `actions` list in
+    `action_name` is the name of the action from the `actions` list in
     the response to GET `/devices/{device_id}`.
 
     This endpoint blocks until confirmation that the Bond has executed


### PR DESCRIPTION
`number` -> `string` to match the actual implementation of this API.

`action_id` -> `action_name` for clarity's sake.

User request on the former: https://forum.bondhome.io/t/api-documentation-requests/278/11