### PR TITLE
Fix underscore-prefixed error fields

### DIFF
--- a/common/schemas.yaml
+++ b/common/schemas.yaml
@@ -1,49 +1,45 @@
 ErrorBaseSchema:
   properties:
-    error_code:
-      example: 2ea086b5-c67f-4185-a0da-1f518a8de42c
-      format: uuid
-      type: string
-    error_id:
+    _error_id:
       example: 1
       type: number
 BadRequest:
   allOf:
   - $ref: '#/ErrorBaseSchema'
   - properties:
-      error_msg:
-        example: The resource wasn't create because has a validation problem
+      _error_msg:
+        example: The resource wasn't created because of a validation problem (This field will have a description of the problem)
         type: string
     type: object
 Conflict:
   allOf:
   - $ref: '#/ErrorBaseSchema'
   - properties:
-      error_msg:
-        example: The resource wasn't create because has a field conflict
+      _error_msg:
+        example: The resource wasn't created because of a field conflict
         type: string
     type: object
 Forbidden:
   allOf:
   - $ref: '#/ErrorBaseSchema'
   - properties:
-      error_msg:
-        example: You don't have authorization for access this resource
+      _error_msg:
+        example: You don't have the authorization to access this resource
         type: string
     type: object
 InternalServerError:
   allOf:
   - $ref: '#/ErrorBaseSchema'
   - properties:
-      error_msg:
-        example: Something unexpected happened
+      _error_msg:
+        example: Something unexpected happened (this field will have a description of the problem)
         type: string
     type: object
 NotFound:
   allOf:
   - $ref: '#/ErrorBaseSchema'
   - properties:
-      error_msg:
+      _error_msg:
         example: Resource not found
         type: string
     type: object
@@ -51,7 +47,7 @@ Unauthorized:
   allOf:
   - $ref: '#/ErrorBaseSchema'
   - properties:
-      error_msg:
+      _error_msg:
         example: You need authentication credentials to continue
         type: string
     type: object


### PR DESCRIPTION
This is to make the docs correct with respect to the implementation.

Why are these fields (`_error_id`, `_error_msg`, and `_id`) underscore-prefixed to begin with? What exactly do we want that underscore to convey?

User request: https://forum.bondhome.io/t/api-documentation-requests/278/16
