### PR TITLE
Add Signal GET response body

### DIFF
--- a/commands/paths.yaml
+++ b/commands/paths.yaml
@@ -173,6 +173,10 @@ SignalGet:
   responses:
     '200':
       description: Signal returned
+      content:
+        application/json:
+          schema:
+            $ref: ../signal/schemas.yaml#/Signal
     '401':
       $ref: ../common/responses.yaml#/Unauthorized
     '404':


### PR DESCRIPTION
Readers could find the form of the body in the PUT and PATCH, but not in the GET