### PR TITLE
devices/x.features: features list

### DIFF
--- a/common/info.yaml
+++ b/common/info.yaml
@@ -479,6 +479,9 @@ description: |
   In order to understand how these relate to each other,
   it is helpful to organize actions into features and study one feature at a time.
 
+  As of firmware v2.11.6, each device endpoint has a list of supported features
+  at `devices/<dev_id>.features`.
+
   ## Power
 
   The Power feature controls the basic on/off state of a device.

--- a/devices/schemas.yaml
+++ b/devices/schemas.yaml
@@ -27,6 +27,14 @@ Device:
     location:
       example: Kitchen
       type: string
+   features:
+      readOnly: true
+      type: array
+      example:
+        - "Power"
+        - "Speed"
+      description: |
+        List of which Features (see list in introduction) are available on this device.
     actions:
       readOnly: true
       type: array


### PR DESCRIPTION
This is something we should have had since day 1. But the last straw was: https://github.com/bondhome/api-v2/pull/16