### PR TITLE
Move bluelight out of bridge endpoint

### DIFF
--- a/bridge/paths.yaml
+++ b/bridge/paths.yaml
@@ -16,10 +16,9 @@ get:
     - OAuth: ["oauth2"]
   summary: Get Bridge info
   description: |
-    Information specific to Bond bridges: `name` and `location` are simply
-    the name and location of the bridge. `bluelight` is the amount of blue
-    light emitted from the Bond when it's idle: at `0` the light is off,
-    and at `255` the light is at its maximum brightness.
+    Information specific to Bonds with multiple devices.
+    `name` and `location` are that of the 'bridging' device, which can be a Bond Bridge
+    or a Smart-by-Bond product that has multiple independantly-controlled devices.
   tags:
   - Bridge
 
@@ -53,7 +52,7 @@ patch:
   - BasicAuth: []
   summary: Change Bridge info
   description: |
-    `bluelight` can vary from 0-255
+    `name` and `location` will each be truncated if they exceed 64 characters
   tags:
   - Bridge
 
@@ -71,9 +70,6 @@ delete:
   - BasicAuth: []
   summary: Reset Bridge info
   description: |
-    After deletion, default values will be restored, as follows:
-    `"My Room"` for location,
-    `"My Bridge"` for name,
-    `255` for bluelight.
+    After deletion, product-specific default values will be restored.
   tags:
   - Bridge

--- a/bridge/schemas.yaml
+++ b/bridge/schemas.yaml
@@ -6,6 +6,3 @@ Bridge:
     name:
       example: My Bridge
       type: string
-    bluelight:
-      example: 127
-      type: int

--- a/debug/leds.yaml
+++ b/debug/leds.yaml
@@ -8,12 +8,12 @@ get:
       description: LED state
   summary: Get LED state
   description: |
-    Get status from the BLED driver.
+    Get status from the LED driver.
 
     If `manual` is `0`, `value` reflects the instantaneous value of the LEDs,
     and may change rapidly and automatically.
   tags:
-  - LEDs
+  - Manual LED Control
 patch:
   requestBody:
     content:
@@ -36,4 +36,4 @@ patch:
     If `manual` is `0` or absent, `value` may still be set, but may be overridden
     at any time.
   tags:
-  - LEDs
+  - Manual LED Control

--- a/local.yaml
+++ b/local.yaml
@@ -47,6 +47,7 @@ x-tagGroups:
       - Wi-Fi Station
       - Wi-Fi Watchdog
       - Upgrade
+      - LEDs
       - Version
       - Reset
       - Reboot
@@ -55,6 +56,6 @@ x-tagGroups:
     tags:
       - Database
       - LiveLog
-      - LEDs
+      - Manual LED Control
       - WiFi
       - RF Manager

--- a/local/paths.yaml
+++ b/local/paths.yaml
@@ -57,6 +57,8 @@
   $ref: ../wifi/paths.yaml#/WifiStaPath
 /v2/sys/wifi/watchdog:
   $ref: ../wifi/paths.yaml#/WifiWatchDogPath
+/v2/sys/leds:
+  $ref: ../sys/leds/path.yaml
 /v2/sys/upgrade:
   $ref: ../wifi/paths.yaml#/WifiUpgradePath
 /v2/sys/version:

--- a/sys/leds/path.yaml
+++ b/sys/leds/path.yaml
@@ -1,0 +1,61 @@
+
+get:
+  responses:
+    '200':
+      description: LED info
+      content:
+        application/json:
+          schema:
+            $ref: schema.yaml
+    '401':
+      $ref: ../../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../../common/responses.yaml#/InternalServerError
+  summary: Get LED
+  description: |
+    Get information about the Bond's LEDs.
+
+    `bluelight` is the amount of blue light emitted from the Bond when it's idle.
+    At `0` the light is off, and at `255` the light is at its maximum brightness.
+  tags:
+  - LEDs
+patch:
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: schema.yaml
+  responses:
+    '200':
+      description: LEDs updated
+    '400':
+      $ref: ../../common/responses.yaml#/BadRequest
+    '401':
+      $ref: ../../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../../common/responses.yaml#/InternalServerError
+  summary: Modify LEDs
+  description: |
+   `bluelight` is the amount of blue light emitted from the Bond when it's idle:
+    at `0` the light is off, and at `255` the light is at its maximum brightness.
+  tags:
+  - LEDs
+delete:
+  responses:
+    '204':
+      description: LED config reset
+    '401':
+      $ref: ../../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../../common/responses.yaml#/InternalServerError
+  summary: Reset LED config to default
+  description: |
+    `bluelight` will be restored to its default value, `127`
+  tags:
+  - LEDs

--- a/sys/leds/path.yaml
+++ b/sys/leds/path.yaml
@@ -13,7 +13,7 @@ get:
       $ref: ../../common/responses.yaml#/NotFound
     '500':
       $ref: ../../common/responses.yaml#/InternalServerError
-  summary: Get LED
+  summary: Get LED config
   description: |
     Get information about the Bond's LEDs.
 
@@ -29,7 +29,7 @@ patch:
           $ref: schema.yaml
   responses:
     '200':
-      description: LEDs updated
+      description: LED config updated
     '400':
       $ref: ../../common/responses.yaml#/BadRequest
     '401':
@@ -38,7 +38,7 @@ patch:
       $ref: ../../common/responses.yaml#/NotFound
     '500':
       $ref: ../../common/responses.yaml#/InternalServerError
-  summary: Modify LEDs
+  summary: Modify LED config
   description: |
    `bluelight` is the amount of blue light emitted from the Bond when it's idle:
     at `0` the light is off, and at `255` the light is at its maximum brightness.
@@ -54,7 +54,7 @@ delete:
       $ref: ../../common/responses.yaml#/NotFound
     '500':
       $ref: ../../common/responses.yaml#/InternalServerError
-  summary: Reset LED config to default
+  summary: Reset LED config
   description: |
     `bluelight` will be restored to its default value, `127`
   tags:

--- a/sys/leds/schema.yaml
+++ b/sys/leds/schema.yaml
@@ -1,0 +1,4 @@
+properties:
+  bluelight:
+    example: 127
+    type: int


### PR DESCRIPTION
I originally intended to keep `bluelight` in the `bridge` endpoint so as not to make a breaking change. However, there are products that have LEDs and need `bluelight` control, but which don't have a "bridging" device (e.g. "TA" devices), so I've decided to split this out.

It is a breaking change, but hopefully one that's relatively painless. Considerations for mobile devs: you'll potentially need to check for both endpoints (`bridge`, `sys/leds`) for `bluelight`. Also, you can rely on the `bridge` endpoint to decide when to display a bridge tile, there's no `"type"` to check against.

Added @apastolibra for visibility in designing the shadow portion of this. Basically, you'll want to add a small `sys/leds` UP handler.

Maybe there's a third-party client that allows setting `bluelight`, so we'll want to announce this change in the forums.

Rendered: https://bond-api-docs.s3.us-east-1.amazonaws.com/jacob-bluelight-local.html