### PR TITLE
actions: PUT returns 200 and argument in body rather than 204

### DIFF
--- a/actions/paths.yaml
+++ b/actions/paths.yaml
@@ -22,8 +22,16 @@ Put:
           example:
             argument: 4
   responses:
+    '200':
+      description: Action executed [since v2.12.4]
+      content:
+        application/json:
+          schema:
+            type: object
+            example:
+              argument: 4
     '204':
-      description: Action executed
+      description: Action executed [prior to v2.12.4]
     '400':
       $ref: ../common/responses.yaml#/BadRequest
     '401':


### PR DESCRIPTION
The devices/{}/actions/{} endpoints will now return a 200 and a copy of the request body, rather than a 204.

<img width="508" alt="Screen Shot 2020-07-15 at 14 50 30" src="https://user-images.githubusercontent.com/628921/87583911-aa2c6e80-c6aa-11ea-91c3-a632c7060146.png">
