### PR TITLE
add sys/eth; move sys/wifi/watchdog to sys/watchdog; make sys/eth, sys/wifi/sta PATCHable

### DIFF
--- a/common/info.yaml
+++ b/common/info.yaml
@@ -220,7 +220,7 @@ description: |
             - commands
             - state
         - sys
-          - wifi
+          - network
 
   Clearly, if the entire tree were expanded on a request of the root,
   then the resulting request may be very large! This large response body

--- a/common/paths.yaml
+++ b/common/paths.yaml
@@ -136,19 +136,19 @@
     $ref: ../users/paths.yaml#/Patch
 /v2/sys/wifi/sta:
   get:
-    $ref: ../wifi/paths.yaml#/StaGet
+    $ref: ../network/paths.yaml#/StaGet
   put:
-    $ref: ../wifi/paths.yaml#/StaPut
+    $ref: ../network/paths.yaml#/StaPut
   delete:
-    $ref: ../wifi/paths.yaml#/StaDelete
+    $ref: ../network/paths.yaml#/StaDelete
 /v2/sys/wifi/scan:
   get:
-    $ref: ../wifi/paths.yaml#/ScanGet
-/v2/sys/wifi/watchdog:
+    $ref: ../network/paths.yaml#/ScanGet
+/v2/sys/watchdog:
   get:
-    $ref: ../wifi/paths.yaml#/WatchdogGet
+    $ref: ../network/paths.yaml#/WatchdogGet
   patch:
-    $ref: ../wifi/paths.yaml#/WatchdogPatch
+    $ref: ../network/paths.yaml#/WatchdogPatch
 /v2/sys/time:
   get:
     $ref: ../sys/paths.yaml#/TimeGet

--- a/local.yaml
+++ b/local.yaml
@@ -45,6 +45,7 @@ x-tagGroups:
     tags:
       - Wi-Fi Scan
       - Wi-Fi Station
+      - Ethernet
       - Network Watchdog
   - name: System
     tags:

--- a/local.yaml
+++ b/local.yaml
@@ -41,11 +41,13 @@ x-tagGroups:
       - Token
       - MQTT
       - BPUP
-  - name: System
+  - name: Network
     tags:
       - Wi-Fi Scan
       - Wi-Fi Station
-      - Wi-Fi Watchdog
+      - Network Watchdog
+  - name: System
+    tags:
       - Upgrade
       - Version
       - Reset

--- a/local/paths.yaml
+++ b/local/paths.yaml
@@ -55,6 +55,8 @@
   $ref: ../network/paths.yaml#/WifiScanPath
 /v2/sys/wifi/sta:
   $ref: ../network/paths.yaml#/WifiStaPath
+/v2/sys/eth:
+  $ref: ../network/paths.yaml#/EthPath
 /v2/sys/watchdog:
   $ref: ../network/paths.yaml#/WifiWatchDogPath
 /v2/sys/upgrade:

--- a/local/paths.yaml
+++ b/local/paths.yaml
@@ -52,19 +52,19 @@
 /v2/api/bpup:
     $ref: ../api/bpup.yaml#/Path
 /v2/sys/wifi/scan:
-  $ref: ../wifi/paths.yaml#/WifiScanPath
+  $ref: ../network/paths.yaml#/WifiScanPath
 /v2/sys/wifi/sta:
-  $ref: ../wifi/paths.yaml#/WifiStaPath
-/v2/sys/wifi/watchdog:
-  $ref: ../wifi/paths.yaml#/WifiWatchDogPath
+  $ref: ../network/paths.yaml#/WifiStaPath
+/v2/sys/watchdog:
+  $ref: ../network/paths.yaml#/WifiWatchDogPath
 /v2/sys/upgrade:
-  $ref: ../wifi/paths.yaml#/WifiUpgradePath
+  $ref: ../network/paths.yaml#/WifiUpgradePath
 /v2/sys/version:
-  $ref: ../wifi/paths.yaml#/WifiVersionPath
+  $ref: ../network/paths.yaml#/WifiVersionPath
 /v2/sys/reset:
-  $ref: ../wifi/paths.yaml#/WifiResetPath
+  $ref: ../network/paths.yaml#/WifiResetPath
 /v2/sys/reboot:
-  $ref: ../wifi/paths.yaml#/WifiRebootPath
+  $ref: ../network/paths.yaml#/WifiRebootPath
 /v2/sys/time:
   $ref: ../sys/paths.yaml#/TimePath
 /v2/sys/power:

--- a/network/paths.yaml
+++ b/network/paths.yaml
@@ -307,7 +307,7 @@ WatchdogPatch:
   - BasicAuth: []
   summary: Configure Network Watchdog
   description: |
-    Configure the Wi-Fi watchdog, which runs whenever the Wi-Fi station (`sta`)
+    Configure the network watchdog, which runs whenever the Wi-Fi station (`sta`)
     is configured.
 
     This watchdog feature is useful on some Wi-Fi networks where the Bond

--- a/network/paths.yaml
+++ b/network/paths.yaml
@@ -310,7 +310,7 @@ WatchdogPatch:
     Configure the network watchdog, which runs whenever the Wi-Fi station (`sta`)
     is configured.
 
-    This watchdog feature is useful on some Wi-Fi networks where the Bond
+    This watchdog feature is useful on some networks where the Bond
     may lose its connection after some period of time.
   tags:
   - Network Watchdog

--- a/network/paths.yaml
+++ b/network/paths.yaml
@@ -1,18 +1,18 @@
 WifiScanPath:
   get:
-    $ref: ../wifi/paths.yaml#/ScanGet
+    $ref: ../network/paths.yaml#/ScanGet
 WifiStaPath:
   get:
-    $ref: ../wifi/paths.yaml#/StaGet
+    $ref: ../network/paths.yaml#/StaGet
   put:
-    $ref: ../wifi/paths.yaml#/StaPut
+    $ref: ../network/paths.yaml#/StaPut
   delete:
-    $ref: ../wifi/paths.yaml#/StaDelete
+    $ref: ../network/paths.yaml#/StaDelete
 WifiWatchDogPath:
   get:
-    $ref: ../wifi/paths.yaml#/WatchdogGet
+    $ref: ../network/paths.yaml#/WatchdogGet
   patch:
-    $ref: ../wifi/paths.yaml#/WatchdogPatch
+    $ref: ../network/paths.yaml#/WatchdogPatch
 WifiUpgradePath:
   get:
     $ref: ../firmware/paths.yaml#/Get
@@ -188,16 +188,16 @@ WatchdogGet:
         application/json:
           schema:
             $ref: schemas.yaml#/Watchdog
-      description: Wi-Fi Watchdog settings
+      description: Network Watchdog settings
     '401':
       $ref: ../common/responses.yaml#/Unauthorized
     '500':
       $ref: ../common/responses.yaml#/InternalServerError
   security:
   - BasicAuth: []
-  summary: Check Wi-Fi Watchdog configuration
+  summary: Check Network Watchdog configuration
   tags:
-  - Wi-Fi Watchdog
+  - Network Watchdog
 WatchdogPatch:
   requestBody:
     content:
@@ -206,14 +206,14 @@ WatchdogPatch:
           $ref: schemas.yaml#/Watchdog
   responses:
     '200':
-      description: Wi-Fi Watchdog config updated
+      description: Network Watchdog config updated
     '401':
       $ref: ../common/responses.yaml#/Unauthorized
     '500':
       $ref: ../common/responses.yaml#/InternalServerError
   security:
   - BasicAuth: []
-  summary: Configure Wi-Fi Watchdog
+  summary: Configure Network Watchdog
   description: |
     Configure the Wi-Fi watchdog, which runs whenever the Wi-Fi station (`sta`)
     is configured.
@@ -221,4 +221,4 @@ WatchdogPatch:
     This watchdog feature is useful on some Wi-Fi networks where the Bond
     may lose its connection after some period of time.
   tags:
-  - Wi-Fi Watchdog
+  - Network Watchdog

--- a/network/paths.yaml
+++ b/network/paths.yaml
@@ -44,10 +44,10 @@ EthGet:
           schema:
             $ref: schemas.yaml#/Eth
       description: Current Etherent settings
+    '404':
+      description: Ethernet unsupported on this product.
     '401':
       $ref: ../common/responses.yaml#/Unauthorized
-    '404':
-      description: Ethernet not available on this product.
   security:
   - BasicAuth: []
   summary: Get current Ethernet settings
@@ -88,7 +88,7 @@ EthPatch:
       content:
         application/json:
           schema:
-            $ref: schemas.yaml#/Sta
+            $ref: schemas.yaml#/Eth
       description: Ethernet settings updated
     '401':
       $ref: ../common/responses.yaml#/Unauthorized

--- a/network/paths.yaml
+++ b/network/paths.yaml
@@ -1,11 +1,18 @@
+EthPath:
+  get:
+    $ref: ../network/paths.yaml#/EthGet
+  patch:
+    $ref: ../network/paths.yaml#/EthPatch
+  delete:
+    $ref: ../network/paths.yaml#/EthDelete
 WifiScanPath:
   get:
     $ref: ../network/paths.yaml#/ScanGet
 WifiStaPath:
   get:
     $ref: ../network/paths.yaml#/StaGet
-  put:
-    $ref: ../network/paths.yaml#/StaPut
+  patch:
+    $ref: ../network/paths.yaml#/StaPatch
   delete:
     $ref: ../network/paths.yaml#/StaDelete
 WifiWatchDogPath:
@@ -29,7 +36,90 @@ WifiResetPath:
 WifiRebootPath:
   put:
     $ref: ../firmware/paths.yaml#/RebootPut
+EthGet:
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            $ref: schemas.yaml#/Eth
+      description: Current Etherent settings
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      description: Ethernet not available on this product.
+  security:
+  - BasicAuth: []
+  summary: Get current Ethernet settings
+  description: |
+    Note that there are seperate DNS settings for the Ethernet and Wi-Fi
+    interfaces.
+  tags:
+  - Ethernet
+EthDelete:
+  responses:
+    '200':
+      description: Ethernet settings reset to defaults
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  security:
+  - BasicAuth: []
+  summary: Reset Ethernet Settings to Default
+  description: |
+    Bond will clear settings for Ethernet, defaulting to DHCP,
+    DHCP-provided DNS (with fallback to hard-coded DNS servers),
+    and Ethernet being preferred over Wi-Fi if both are available.
 
+    This will NOT disable the Ethernet port. If the attached network
+    supports DHCP and has an internet connection, the Bond will continue
+    to function on Ethernet.
+  tags:
+  - Ethernet
+EthPatch:
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: schemas.yaml#/Eth
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            $ref: schemas.yaml#/Sta
+      description: Ethernet settings updated
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  security:
+  - BasicAuth: []
+  summary: Customize Ethernet settings
+  description: |
+    For compatibility reasons, the PATCH endpoint can also be accessed
+    using the PUT method.
+
+    Customize the Ethernet interface.
+
+    The Bond immediately saves the settings in non-volatile storage,
+    and therefore the settings will persist even after power cycle.
+
+    If `ip`, `gw`, and `netmask` are all present, the Bond will attempt to use
+    the three values to configure its Ethernet interface's IP address, default gateway,
+    and netmask, respectively. If any of these fields are present, all three must
+    be present.
+
+    For DNS, Bond always tries default DNS servers first. However, our chosen
+    DNS servers are blocked on some networks, so Bond will fall back to DNS
+    servers provided by DHCP or specified by `dns` and `dns_alt`. If `dns` or
+    `dns_alt` are provided, Bond will ignore any DNS servers proposed
+    by DHCP. This behavior was decided upon after many customer service interactions
+    which revealed an epidemic of bad ISP DNS servers which prevent what we
+    originally though was reasonable: respecting the DHCP-provided servers by default.
+  tags:
+  - Wi-Fi Station
 StaGet:
   responses:
     '200':
@@ -48,13 +138,7 @@ StaGet:
   description: |
     Get the name (base64-encoded in `ssid`) of the Wi-Fi network to which the Bond is currently connected.
 
-    The `status` field gives an indication of whether the Wi-Fi settings
-    have been successful:
-      - -2 = authentication failure
-      - -1 = network not found
-      - 0 = attempting to connect
-      - 1 = connected, but no IP address (yet)
-      - 2 = connected with IP address assigned
+    A numerical `status` field is also provided (see details below).
 
     The BSSID of the network's access point is provided, hex-encoded in `bssid`.
     If `bssid_set` is present and `true`, then the Bond has been configured to
@@ -89,7 +173,7 @@ StaDelete:
     It will be necessary to use PUT again to reconfigure Wi-Fi.
   tags:
   - Wi-Fi Station
-StaPut:
+StaPatch:
   requestBody:
     content:
       application/json:
@@ -110,6 +194,9 @@ StaPut:
   - BasicAuth: []
   summary: Connect to a Wi-Fi network
   description: |
+    For compatibility reasons, the PATCH endpoint can also be accessed
+    using the PUT method.
+
     Instruct the Bond to connect to the network specified.
 
     The Bond immediately saves the settings in non-volatile storage,
@@ -124,8 +211,13 @@ StaPut:
     and netmask, respectively. If any of these fields are present, all three must
     be present.
 
-    If `dns` or `dns_alt` are present, the Bond will use them in place of its
-    default main DNS and fallback DNS, respectively.
+    For DNS, Bond always tries default DNS servers first. However, our chosen
+    DNS servers are blocked on some networks, so Bond will fall back to DNS
+    servers provided by DHCP or specified by `dns` and `dns_alt`. If `dns` or
+    `dns_alt` are provided, Bond will ignore any DNS servers proposed
+    by DHCP. This behavior was decided upon after many customer service interactions
+    which revealed an epidemic of bad ISP DNS servers which prevent what we
+    originally though was reasonable: respecting the DHCP-provided servers by default.
 
     If `bssid` is present, the Bond will only connect to an access point with the supplied,
     hex-encoded BSSID.

--- a/network/schemas.yaml
+++ b/network/schemas.yaml
@@ -118,7 +118,6 @@ Eth:
     dns:
       example: '8.8.8.8'
       type: string
-      decription:
     dns_alt_set:
       readOnly: true
       example: true

--- a/network/schemas.yaml
+++ b/network/schemas.yaml
@@ -28,6 +28,15 @@ Sta:
     status:
       example: 2
       type: number
+      description: |
+        Indication of whether the Wi-Fi settings have been successful:
+          - -3 = disabled because Ethernet is selected
+          - -2 = authentication failure
+          - -1 = network not found
+          - 0 = attempting to connect
+          - 1 = connected, but no IP address yet
+          - 2 = connected with IP address assigned
+          - 3 = connected to cloud (MQTT)
     ssid:
       example: bGlua3N5cw==
       type: string
@@ -74,6 +83,60 @@ Sta:
       format: password
       type: string
       writeOnly: true
+Eth:
+  properties:
+    status:
+      example: 2
+      type: number
+      description: |
+          - -3 = disabled because Wi-Fi is configured and preferred
+          - 0 = no link
+          - 1 = link, but no IP address yet
+          - 2 = link and IP address assigned
+          - 3 = connected to cloud (MQTT)
+    mac:
+      example: '30aea48fa8e8'
+      type: string
+      readOnly: true
+    static_ip_set:
+      readOnly: true
+      example: false
+      type: boolean
+    ip:
+      example: '192.168.1.42'
+      type: string
+    gw:
+      example: '192.168.1.1'
+      type: string
+    netmask:
+      example: '255.255.255.0'
+      type: string
+    dns_set:
+      readOnly: true
+      example: true
+      type: boolean
+    dns:
+      example: '8.8.8.8'
+      type: string
+      decription:
+    dns_alt_set:
+      readOnly: true
+      example: true
+      type: boolean
+    dns_alt:
+      example: '8.8.4.4'
+      type: string
+    preferred:
+      example: true
+      type: boolean
+      description: |
+        If true (default), Bond will select Ethernet whenever Ethernet link
+        is available, even if Wi-Fi is associated to a network.
+
+        If false, Bond will not use Ethernet if Wi-Fi is associated.
+
+        Regardless of this setting, if Wi-Fi is not associated, Bond will
+        try to use Ethernet.
 Scan:
   example:
     hidden_requires_bssid: true

--- a/network/schemas.yaml
+++ b/network/schemas.yaml
@@ -10,6 +10,8 @@ Watchdog:
         If enabled, Bond will reboot if not connected to Bond Cloud
         within first 10 minutes of boot, or if disconnected for 3 minutes.
 
+        Watchdog does not run if Bond is in Wi-Fi Setup mode.
+
         NOTE: Any communication with the Bond over the HTTP transport
         will reset the timer as if the Bond were connected to the cloud.
     rwdg_timer_ms:


### PR DESCRIPTION
Ethernet endpoint and related changes for Bond Bridge Pro (to be released as `v2.16` firmware).

Render: https://bond-api-docs.s3.amazonaws.com/merck-ethernet-local.html
