### PR TITLE
sys/eth, sys/wifi/sta: add PATCH support; static_ip_set, dns_set writeable

### DIFF
--- a/network/paths.yaml
+++ b/network/paths.yaml
@@ -99,17 +99,12 @@ EthPatch:
   summary: Customize Ethernet settings
   description: |
     For compatibility reasons, the PATCH endpoint can also be accessed
-    using the PUT method.
+    using the deprecated PUT method.
 
     Customize the Ethernet interface.
 
     The Bond immediately saves the settings in non-volatile storage,
     and therefore the settings will persist even after power cycle.
-
-    If `ip`, `gw`, and `netmask` are all present, the Bond will attempt to use
-    the three values to configure its Ethernet interface's IP address, default gateway,
-    and netmask, respectively. If any of these fields are present, all three must
-    be present.
 
     For DNS, Bond always tries default DNS servers first. However, our chosen
     DNS servers are blocked on some networks, so Bond will fall back to DNS
@@ -119,7 +114,7 @@ EthPatch:
     which revealed an epidemic of bad ISP DNS servers which prevent what we
     originally though was reasonable: respecting the DHCP-provided servers by default.
   tags:
-  - Wi-Fi Station
+  - Ethernet
 StaGet:
   responses:
     '200':
@@ -205,11 +200,6 @@ StaPatch:
     The network name must be specified in `ssid` (base64-encoded).
     A `password` (again base64-encoded) is required unless it is an unsecured (open) network.
     The required security type (WEP/WPA/WPA2) is automatically determined by the Bond.
-
-    If `ip`, `gw`, and `netmask` are all present, the Bond will attempt to use
-    the three values to configure its STA interface's IP address, default gateway,
-    and netmask, respectively. If any of these fields are present, all three must
-    be present.
 
     For DNS, Bond always tries default DNS servers first. However, our chosen
     DNS servers are blocked on some networks, so Bond will fall back to DNS
@@ -307,10 +297,10 @@ WatchdogPatch:
   - BasicAuth: []
   summary: Configure Network Watchdog
   description: |
-    Configure the network watchdog, which runs whenever the Wi-Fi station (`sta`)
+    Configure the Wi-Fi watchdog, which runs whenever the Wi-Fi station (`sta`)
     is configured.
 
-    This watchdog feature is useful on some networks where the Bond
+    This watchdog feature is useful on some Wi-Fi networks where the Bond
     may lose its connection after some period of time.
   tags:
   - Network Watchdog

--- a/network/schemas.yaml
+++ b/network/schemas.yaml
@@ -52,9 +52,13 @@ Sta:
       type: string
       readOnly: true
     static_ip_set:
-      readOnly: true
       example: false
       type: boolean
+      description: |
+        [changed in v2.16.2]
+        If true on write, the ip, gw, netmask fields are required.
+        If false on write, the ip, gw, netmask fields will be ignored
+         and DHCP configured.
     ip:
       example: '192.168.1.42'
       type: string
@@ -65,16 +69,16 @@ Sta:
       example: '255.255.255.0'
       type: string
     dns_set:
-      readOnly: true
       example: true
       type: boolean
+      description: |
+        [changed in v2.16.2]
+        If true on write, the dns and dns_alt fields are required.
+        If false on write, the dns and dns_alt fields will be ignored
+          and the default dns behavior will take effect.
     dns:
       example: '8.8.8.8'
       type: string
-    dns_alt_set:
-      readOnly: true
-      example: true
-      type: boolean
     dns_alt:
       example: '8.8.4.4'
       type: string
@@ -99,9 +103,13 @@ Eth:
       type: string
       readOnly: true
     static_ip_set:
-      readOnly: true
       example: false
       type: boolean
+      description: |
+        [changed in v2.16.2]
+        If true on write, the ip, gw, netmask fields are required.
+        If false on write, the ip, gw, netmask fields will be ignored
+         and DHCP configured.
     ip:
       example: '192.168.1.42'
       type: string
@@ -112,16 +120,16 @@ Eth:
       example: '255.255.255.0'
       type: string
     dns_set:
-      readOnly: true
       example: true
       type: boolean
+      description: |
+        [changed in v2.16.2]
+        If true on write, the dns and dns_alt fields are required.
+        If false on write, the dns and dns_alt fields will be ignored
+          and the default dns behavior will take effect.
     dns:
       example: '8.8.8.8'
       type: string
-    dns_alt_set:
-      readOnly: true
-      example: true
-      type: boolean
     dns_alt:
       example: '8.8.4.4'
       type: string
@@ -129,6 +137,8 @@ Eth:
       example: true
       type: boolean
       description: |
+        [not yet implemented]
+
         If true (default), Bond will select Ethernet whenever Ethernet link
         is available, even if Wi-Fi is associated to a network.
 


### PR DESCRIPTION
corresponding to bond-core implementation: https://github.com/ZolibraBond/bond-core/issues/1008

Should be reverse-compatible with apps. Current setup flow (PUT) does not need to change.

However, this new PATCH API is needed for the Network Settings screen to change IP / DNS config.