### PR TITLE
sys/locale: move compliance_region field here

### DIFF
--- a/bridge/schemas.yaml
+++ b/bridge/schemas.yaml
@@ -12,16 +12,6 @@ Bridge:
       description: |
         Amount of blue light emitted from the Bond when it's idle: at `0` the light is off,
         and at `255` the light is at its maximum brightness.
-    compliance_region:
-      example: au
-      type: string
-      description: |
-        Region for radio frequency compliance.
-        This option must be set by the client (Bond Home app) during setup.
-        String is a two-digit country code (ISO 3166-1 alpha-2).
-        Supported options:
-          - us: USA, Canada, Mexico
-          - au: Australia [v2.15]
     frequencies:
       read_only: true
       example: [[38, 38], [433050, 434079]]

--- a/local.yaml
+++ b/local.yaml
@@ -55,6 +55,7 @@ x-tagGroups:
       - Reboot
       - Time
       - Power
+      - Locale
   - name: Debug
     tags:
       - Database

--- a/local/paths.yaml
+++ b/local/paths.yaml
@@ -11,6 +11,8 @@
     $ref: ../debug/beau.yaml
 /v2/bridge:
     $ref: ../bridge/paths.yaml
+/v2/sys/locale:
+    $ref: ../locale/paths.yaml
 /v2/devices:
     $ref: ../devices/paths.yaml#/DevicesPath
 /v2/devices/{device_id}:

--- a/locale/paths.yaml
+++ b/locale/paths.yaml
@@ -1,0 +1,62 @@
+get:
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            $ref: schemas.yaml#/Locale
+      description: Get Locale info
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  security:
+    - OAuth: ["oauth2"]
+  summary: Get Locale info
+  tags:
+  - Locale
+
+patch:
+  requestBody:
+    content:
+      application/json:
+        schema:
+            $ref: schemas.yaml#/Locale
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            $ref: schemas.yaml#/Locale
+      description: Change Locale info
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  security:
+  - BasicAuth: []
+  summary: Change Locale info
+  tags:
+  - Locale
+
+delete:
+  responses:
+    '204':
+      description: Reset Locale info
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  security:
+  - BasicAuth: []
+  summary: Reset Locale info
+  description: |
+    After deletion, default values will be restored.
+  tags:
+  - Locale

--- a/locale/schemas.yaml
+++ b/locale/schemas.yaml
@@ -1,0 +1,12 @@
+Locale:
+  properties:
+    compliance_region:
+      example: au
+      type: string
+      description: |
+        Region for radio frequency compliance.
+        This option must be set by the client (Bond Home app) during setup.
+        String is a two-digit country code (ISO 3166-1 alpha-2).
+        Supported options:
+          - us: USA, Canada, Mexico
+          - au: Australia [v2.15]


### PR DESCRIPTION
Purpose: so that SBB devices can have Australia region set for access to extra Wi-Fi channels.