### PR TITLE
backup: fix visibility

### DIFF
--- a/common/paths.yaml
+++ b/common/paths.yaml
@@ -172,13 +172,6 @@
 /v2/sys/free:
   get:
     $ref: ../firmware/paths.yaml#/FreeGet
-/v2/sys/backup:
-  get:
-    $ref: ../firmware/paths.yaml#/BackupGet
-  put:
-    $ref: ../firmware/paths.yaml#/BackupPut
-  delete:
-    $ref: ../firmware/paths.yaml#/BackupDelete
 /v2/sys/reset:
   put:
     $ref: ../firmware/paths.yaml#/ResetPut

--- a/firmware/schemas.yaml
+++ b/firmware/schemas.yaml
@@ -258,7 +258,7 @@ Backup:
 
         Format:
 
-          /<bond-id>_<fw-ver>_<timestamp>_<random>.bsnap
+          `/<bond-id>_<fw-ver>_<timestamp>_<random>.bsnap`
 
         Timestamp is as provided by client.
     dev_ids:

--- a/local/paths.yaml
+++ b/local/paths.yaml
@@ -73,3 +73,10 @@
   $ref: ../sys/paths.yaml#/TimePath
 /v2/sys/power:
   $ref: ../sys/paths.yaml#/PowerPath
+/v2/sys/backup:
+  get:
+    $ref: ../firmware/paths.yaml#/BackupGet
+  put:
+    $ref: ../firmware/paths.yaml#/BackupPut
+  delete:
+    $ref: ../firmware/paths.yaml#/BackupDelete


### PR DESCRIPTION
@endy-s reported that the Backup endpoint docs were not visible. I'm not sure why `common/paths.yaml` is not being read. Anyways, moving to `local/paths.yaml` fixes the issue for now.