### PR TITLE
Leading Zero Rule for 64-bit keys [v3]

### DIFF
--- a/common/info.yaml
+++ b/common/info.yaml
@@ -1,6 +1,6 @@
 ---
 title: Bond API
-version: "v2.18.2"
+version: "v2.22"
 x-logo:
   url: https://s3.amazonaws.com/docs-cloud.appbond.com/bond.png
 description: |
@@ -213,6 +213,27 @@ description: |
       curl -H "BOND-Token: f074b61f628018fd" -i http://192.100.0.61/v2/devices/79135791/actions/SetSpeed -X PUT -d "{\"argument\": 3}"
 
   # API Concepts
+
+  ## 64-bit Keys
+
+  As of v2.22 firmware, Bond products have moved to 64-bit keys as resource
+  identifiers, instead of the previous 32-bit keys. So, rather than a device
+  being identified by an 8-digit hex string, the ids for newly created devices
+  will be 16-digit hex strings.
+
+  In an effort to minimize distruption to API clients,
+  already created resources (devices, commands, skeds, etc.) will continue
+  to be represented using the same exact string on the API. Additional
+  leading zeros will not be added. So, for example, a device with id `01abcdef`
+  will continue to enumerate as `01abcdef` in v2.22. The Bond API is however
+  libral in what it accepts, removing leading zeros.
+  So any of the following received ids will be
+  understood to point to this device: `1abcdef`, `01abcdef`, `0000000001abcdef`.
+
+  Internally, the Bond API uses this rule:
+
+    If the upper 32-bits of an ID are zero, then send as 8 hex digits (32-bit).
+    Otherwise, send as 16 hex digits (64-bit).
 
   ## Hash Tree
 

--- a/common/info.yaml
+++ b/common/info.yaml
@@ -1,6 +1,6 @@
 ---
 title: Bond API
-version: "v2.22"
+version: "v3.0.0"
 x-logo:
   url: https://s3.amazonaws.com/docs-cloud.appbond.com/bond.png
 description: |
@@ -216,7 +216,7 @@ description: |
 
   ## 64-bit Keys
 
-  As of v2.22 firmware, Bond products have moved to 64-bit keys as resource
+  As of v3.0.0 firmware, Bond products have moved to 64-bit keys as resource
   identifiers, instead of the previous 32-bit keys. So, rather than a device
   being identified by an 8-digit hex string, the ids for newly created devices
   will be 16-digit hex strings.

--- a/local/info.yaml
+++ b/local/info.yaml
@@ -1,6 +1,6 @@
 ---
 title: Bond Local API
-version: "v2.22"
+version: "v3.0.0"
 x-logo:
   url: https://s3.amazonaws.com/docs-cloud.appbond.com/bond.png
 description:

--- a/local/info.yaml
+++ b/local/info.yaml
@@ -1,6 +1,6 @@
 ---
 title: Bond Local API
-version: "v2.20.14"
+version: "v2.22"
 x-logo:
   url: https://s3.amazonaws.com/docs-cloud.appbond.com/bond.png
 description:


### PR DESCRIPTION
 ## 64-bit Keys

  As of v3 firmware, Bond products have moved to 64-bit keys as resource identifiers, instead of the previous 32-bit keys. So, rather than a device being identified by an 8-digit hex string, the ids for newly created devices will be 16-digit hex strings.

  In an effort to minimize distruption to API clients, already created resources (devices, commands, skeds, etc.) will continue to be represented using the same exact string on the API. Additional leading zeros will not be added. So, for example, a device with id `01abcdef` will continue to enumerate as `01abcdef` in v3. The Bond API is however liberal in what it accepts, removing leading zeros.

  So any of the following received ids will be understood to point to this device: `1abcdef`, `01abcdef`, `0000000001abcdef`.

  Internally, the Bond API uses this rule:

      If the upper 32-bits of an ID are zero, then send as 8 hex digits (32-bit).
      Otherwise, send as 16 hex digits (64-bit).

## Will It Break Something?

I checked on our backend, and there's no customer Bridge-assisted devices with != 8 character length ids. Same for commands. A spot check of skeds show that the leading zero is present. Therefore, I believe that the rule described in this PR will work transparently for the backend and apps.

EDIT: Example reply to GET devices when there's a bunch of old devices and one new device:

```"b":{"_":"907587bf","5fc9f4ab":{"_":"0e6a20fd"},"0870247f":{"_":"632d85e5"},"186fa0d7":{"_":"6a7c2151"},"35080cac":{"_":"bf35417c"},"30fc7570":{"_":"5ffd9a90"},"196ef914":{"_":"88c5d404"},"65eda27ce0fc2ec2":{"_":"be87fafc"}}```