### PR TITLE
Scenes

### DIFF
--- a/actions/group-paths.yaml
+++ b/actions/group-paths.yaml
@@ -1,0 +1,52 @@
+ActionPath:
+  put:
+    $ref: ../actions/group-paths.yaml#/Put
+  parameters:
+  - in: path
+    name: action_name
+    required: true
+    schema:
+      type: string
+  - in: path
+    name: group_id
+    required: true
+    schema:
+      type: number
+
+Put:
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+          example:
+            argument: 4
+  responses:
+    '200':
+      description: Action executed
+      content:
+        application/json:
+          schema:
+            type: object
+            example:
+              argument: 4
+    '400':
+      $ref: ../common/responses.yaml#/BadRequest
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  summary: Execute a Group Action
+  description: |
+    `action_name` is the name of the action from the `actions` list in
+    the response to GET `/groups/{group_id}`.
+
+    This endpoint blocks until confirmation that the Bond has executed
+    the Action on all member Devices. Timeout shall be no more than 7 seconds.
+
+    To check the resulting state, the client may query
+    `/groups/{group_id}/state`, but the member Device States are also updated.
+  tags:
+  - Group Actions
+  security:
+    - OAuth: ["oauth2"]

--- a/actions/scene-paths.yaml
+++ b/actions/scene-paths.yaml
@@ -1,0 +1,54 @@
+ActionPath:
+  put:
+    $ref: ../actions/scene-paths.yaml#/Put
+  parameters:
+  - in: path
+    name: action_name
+    required: true
+    schema:
+      type: string
+  - in: path
+    name: scene_id
+    required: true
+    schema:
+      type: number
+
+Put:
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+          example:
+            argument: 4
+  responses:
+    '200':
+      description: Action executed
+      content:
+        application/json:
+          schema:
+            type: object
+            example:
+              argument: 4
+    '400':
+      $ref: ../common/responses.yaml#/BadRequest
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  summary: Activate a Scene
+  description: |
+    `action_name` must be "Activate". In other words,
+    a Scene supports exactly one action called "Activate".
+
+    This endpoint blocks until confirmation that the Bond has executed
+    (but not necessarily fulfilled)
+    the Actions on all member Devices. Timeout shall be no more than 7 seconds.
+
+    To check the resulting state, the client may query
+    `/scenes/{scene_id}/state`, but the member Device and Group States
+    are also updated.
+  tags:
+  - Scene Actions
+  security:
+    - OAuth: ["oauth2"]

--- a/groups/paths.yaml
+++ b/groups/paths.yaml
@@ -43,6 +43,12 @@ GroupsPath:
         $ref: ../common/responses.yaml#/InternalServerError
     summary: Create new Group
     description: |
+      For the creation of a Group distributed across multiple Bonds,
+      clients should generate a random 64-bit ID for the Group and provide that
+      same ID in each Group POST request in the `_id` field. If the `_id`
+      field is not provided, a random ID will be assigned as with
+      POST requests to other enumerations.
+
       If `devices` is not provided, an empty Group is created.
       If `devices` is an array of device IDs, then a Group is created
       containing those device IDs. Using the `devices` field requires

--- a/groups/paths.yaml
+++ b/groups/paths.yaml
@@ -229,9 +229,8 @@ Patch:
   - BasicAuth: []
   summary: Add Device to Group or Change Group field
   description: |
-    If `devices` argument is provided, it specifies a Device to add to
-    the Group. Only one Device can be added at once. Nonetheless, `devices`
-    must be an array with that one element.
+    If `devices` argument is provided, it specifies one or more Devices to add to
+    the Group.
   tags:
   - Groups
 Delete:
@@ -254,9 +253,8 @@ Delete:
   - BasicAuth: []
   summary: Remove Device from Group or Delete Group
   description: |
-    If `devices` argument is provided, it specifies a Device to remove from
-    the Group. Only one Device can be removed at once. Nonetheless, `devices`
-    must be an array with that one element.
+    If `devices` argument is provided, it specifies one or more Device to remove from
+    the Group.
 
     If `devices` argument is not provided, then the entire Group is deleted.
   tags:

--- a/groups/paths.yaml
+++ b/groups/paths.yaml
@@ -1,0 +1,290 @@
+GroupsPath:
+  get:
+    description: |
+      Returns a list of Group IDs and the corresponding Group hashes.
+      The hashes change if any part of the Group (its name, state, type, etc.)
+      has changed. The hash is not updated if underlying Devices are updated
+      in a way which does not effect the Group state or type.
+
+      Groups are only supported on Bond Bridges, not on Smart by Bond.
+      Furthermore, Groups may only include Devices on the same Bridge.
+    responses:
+      '200':
+        content:
+          application/json:
+            schema:
+              $ref: schemas.yaml#/GroupList
+        description: List Groups
+      '401':
+        $ref: ../common/responses.yaml#/Unauthorized
+      '500':
+        $ref: ../common/responses.yaml#/InternalServerError
+    security:
+      - OAuth: ["oauth2"]
+    summary: List your Groups
+    tags:
+    - Groups
+  post:
+    requestBody:
+      content:
+        application/json:
+          schema:
+            $ref: ../groups/schemas.yaml#/Group
+    responses:
+      '201':
+        $ref: ../common/responses.yaml#/Created
+      '400':
+        $ref: ../common/responses.yaml#/BadRequest
+      '401':
+        $ref: ../common/responses.yaml#/Unauthorized
+      '409':
+        $ref: ../common/responses.yaml#/Conflict
+      '500':
+        $ref: ../common/responses.yaml#/InternalServerError
+    summary: Create new Group
+    tags:
+    - Groups
+
+GroupPath:
+  get:
+    $ref: ../groups/paths.yaml#/Get
+  parameters:
+    - in: path
+      name: Group_id
+      required: true
+      schema:
+        type: number
+  patch:
+    $ref: ../groups/paths.yaml#/Patch
+  delete:
+    $ref: ../groups/paths.yaml#/Delete
+
+StatePath:
+  get:
+    $ref: ../groups/paths.yaml#/GetState
+  parameters:
+  - in: path
+    name: Group_id
+    required: true
+    schema:
+      type: number
+
+PropertiesPath:
+  get:
+    $ref: ../groups/paths.yaml#/GetProperties
+  patch:
+    $ref: ../groups/paths.yaml#/PatchProperties
+  parameters:
+  - in: path
+    name: Group_id
+    required: true
+    schema:
+      type: number
+GetProperties:
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            $ref: ../devices/schemas.yaml#/Properties
+      description: Get Group properties
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  security:
+    - OAuth: ["oauth2"]
+  summary: Get Group properties
+  description: |
+    See the Features section above for other properties which may be available
+    on your Groups.
+
+    Similar to the Group State object, the Properties available for a Group
+    are those Properties which exist on every Device in the Group.
+    If all Devices have the same value for a Property, then that value will
+    be provided here. If Devices do not agree on a value, then that Property
+    will be listed but with a `null` value.
+  tags:
+  - Group Properties
+
+PatchProperties:
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: ../devices/schemas.yaml#/Properties
+  responses:
+    '200':
+      description: Properties updated
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  security:
+    - OAuth: ["oauth2"]
+  summary: Update properties
+  description: |
+    PATCHing one or more Group Properties implicitely PATCHes those Properties
+    on all Devices in the Group. Gratuitous PATCH replies are sent for each
+    Device before this PATCH reply returns. If any errors occur in any of the
+    underlying Device PATCH requests, this request will return a 500 error
+    and the Devices' Properties will be left in undefined condition.
+
+    Example: If you set up 8 individual shades in your kitchen and then add
+    them all to a Group, you can then, with a single request, enable or disable
+    the `feature_position` Property to enable/disable the "slider" feature.
+    [This "slider" feature is avaiable only on the Bond Bridge Pro.]
+  tags:
+  - Group Properties
+
+GetList:
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            $ref: schemas.yaml#/GroupList
+      description: List active Groups
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  security:
+    - OAuth: ["oauth2"]
+  summary: List your Groups
+  tags:
+  - Groups
+Post:
+  requestBody:
+    content:
+      application/json:
+        schema:
+          required: true
+          $ref: schemas.yaml#/Group
+  responses:
+    '201':
+      $ref: ../common/responses.yaml#/Created
+    '400':
+      $ref: ../common/responses.yaml#/BadRequest
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '409':
+      $ref: ../common/responses.yaml#/Conflict
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  summary: Create new Group
+  description: |
+    Note that `type` cannot be specified when creating a Group.
+    The `type` field is calculated based on the member Devices.
+  tags:
+  - Groups
+Get:
+  description: |
+    Groups are collections of Devices on a single Bridge.
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            required: true
+            $ref: schemas.yaml#/Group
+      description: Get Group
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  security:
+    - OAuth: ["oauth2"]
+  summary: Get Group
+  tags:
+  - Groups
+Patch:
+  requestBody:
+    content:
+      application/json:
+        schema:
+          required: true
+          $ref: schemas.yaml#/Group
+          type: object
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            $ref: schemas.yaml#/Group
+      description: Change Group field
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  security:
+  - BasicAuth: []
+  summary: Add Device to Group or Change Group field
+  description: |
+    If `devices` argument is provided, it specifies a Device to add to
+    the Group. Only one Device can be added at once. Nonetheless, `devices`
+    must be an array with that one element.
+  tags:
+  - Groups
+Delete:
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: schemas.yaml#/GroupDeletion
+          type: object
+  responses:
+    '204':
+      description: Remove Group or Device from Group
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  security:
+  - BasicAuth: []
+  summary: Remove Device from Group or Delete Group
+  description: |
+    If `devices` argument is provided, it specifies a Device to remove from
+    the Group. Only one Device can be removed at once. Nonetheless, `devices`
+    must be an array with that one element.
+
+    If `devices` argument is not provided, then the entire Group is deleted.
+  tags:
+  - Groups
+
+GetState:
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            $ref: schemas.yaml#/State
+      description: Get Group State
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  security:
+    - OAuth: ["oauth2"]
+  summary: Get Group State
+  description: |
+    Group State lists those state variables which are common to all member
+    Devices. If all member Devices have the same value for a particular state
+    variable, then the Group variable will take that value. However, if member
+    Devices differ in value, then the Group variable will take the value `null`.
+
+    Note that Group states cannot be PATCHed.
+  tags:
+  - Group State

--- a/groups/paths.yaml
+++ b/groups/paths.yaml
@@ -42,6 +42,18 @@ GroupsPath:
       '500':
         $ref: ../common/responses.yaml#/InternalServerError
     summary: Create new Group
+    description: |
+      If `devices` is not provided, an empty Group is created.
+      If `devices` is an array of device IDs, then a Group is created
+      containing those device IDs. Using the `devices` field requires
+      the client to predetermine what devices are compatible in the sense
+      of having a non-empty Actions ntersection. For this reason, it is
+      simpler for the client to make individual Groups Devices POSTs for each
+      device to be added to the Group, so that the Bond firmware may provide
+      a 400 error in case a device cannot be added due to incompatability.
+
+      Note that `type` cannot be specified when creating a Group.
+      The `type` field is calculated based on the member Devices.
     tags:
     - Groups
 
@@ -185,9 +197,6 @@ Post:
     '500':
       $ref: ../common/responses.yaml#/InternalServerError
   summary: Create new Group
-  description: |
-    Note that `type` cannot be specified when creating a Group.
-    The `type` field is calculated based on the member Devices.
   tags:
   - Groups
 Get:

--- a/groups/paths.yaml
+++ b/groups/paths.yaml
@@ -50,7 +50,7 @@ GroupPath:
     $ref: ../groups/paths.yaml#/Get
   parameters:
     - in: path
-      name: Group_id
+      name: group_id
       required: true
       schema:
         type: number
@@ -64,7 +64,7 @@ StatePath:
     $ref: ../groups/paths.yaml#/GetState
   parameters:
   - in: path
-    name: Group_id
+    name: group_id
     required: true
     schema:
       type: number
@@ -76,7 +76,7 @@ PropertiesPath:
     $ref: ../groups/paths.yaml#/PatchProperties
   parameters:
   - in: path
-    name: Group_id
+    name: group_id
     required: true
     schema:
       type: number

--- a/groups/paths.yaml
+++ b/groups/paths.yaml
@@ -59,6 +59,14 @@ GroupPath:
   delete:
     $ref: ../groups/paths.yaml#/Delete
 
+DevicesPath:
+  post:
+    $ref: ../groups/paths.yaml#/DevicesPost
+
+DevicePath:
+  delete:
+    $ref: ../groups/paths.yaml#/DeviceDelete
+
 StatePath:
   get:
     $ref: ../groups/paths.yaml#/GetState
@@ -227,22 +235,16 @@ Patch:
       $ref: ../common/responses.yaml#/InternalServerError
   security:
   - BasicAuth: []
-  summary: Add Device to Group or Change Group field
+  summary: Change Group field
   description: |
-    If `devices` argument is provided, it specifies one or more Devices to add to
-    the Group.
+    To add or remove Devices from the Group,
+    use the Group Devices endpoint's PUT and DELETE methods instead of this one.
   tags:
   - Groups
 Delete:
-  requestBody:
-    content:
-      application/json:
-        schema:
-          $ref: schemas.yaml#/GroupDeletion
-          type: object
   responses:
     '204':
-      description: Remove Group or Device from Group
+      description: Delete Group
     '401':
       $ref: ../common/responses.yaml#/Unauthorized
     '404':
@@ -251,14 +253,80 @@ Delete:
       $ref: ../common/responses.yaml#/InternalServerError
   security:
   - BasicAuth: []
-  summary: Remove Device from Group or Delete Group
+  summary: Delete Group
   description: |
-    If `devices` argument is provided, it specifies one or more Device to remove from
-    the Group.
-
-    If `devices` argument is not provided, then the entire Group is deleted.
+    The entire Group is deleted.
   tags:
   - Groups
+
+DevicesPost:
+  parameters:
+  - in: path
+    name: group_id
+    required: true
+    schema:
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          properties:
+            device:
+              example: "aabbccdd"
+              type: string
+              description: |
+                ID of Device to add
+  responses:
+    '204':
+      description: Add Device to Group
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  security:
+  - BasicAuth: []
+  summary: Add Device to Group
+  description: |
+    Device with the specified ID is added to the Group.
+
+    A gratuitous update of the corresponding Group endpoint will occur
+    to update clients as to the new devices, actions, state, and properties.
+  tags:
+  - Group Devices
+
+DeviceDelete:
+  parameters:
+  - in: path
+    name: group_id
+    required: true
+    schema:
+      type: string
+  - in: path
+    name: device_id
+    required: true
+    schema:
+      type: string
+  responses:
+    '204':
+      description: Remove Device from Group
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  security:
+  - BasicAuth: []
+  summary: Remove Device from Group
+  description: |
+    Device with the ID specified in the URL is removed from the Group.
+
+    A gratuitous update of the corresponding Group endpoint will occur
+    to update clients as to the new devices, actions, state, and properties.
+  tags:
+  - Group Devices
 
 GetState:
   responses:

--- a/groups/schemas.yaml
+++ b/groups/schemas.yaml
@@ -1,0 +1,77 @@
+Group:
+  properties:
+    name:
+      example: Kitchen Shades
+      type: string
+    devices:
+      description: |
+        List of member Device IDs.
+      type: array
+      example:
+        - "aabbccdd"
+        - "11223344"
+        - "deadbeef"
+    type:
+      readOnly: true
+      description: |
+        For values, see `type` field of Device schema.
+
+        Type is automatically set by the Bond Bridge to be the type of the
+        underlying devices when all devices are of the same type. Note that
+        Group type is always an array, even if it has zero or one element.
+
+        When devies of multiple types are mixed in a single Group,
+        this `type` lists each type.
+        For example, a Ceiling Fan (CF) and a Light (LT) combined would be
+        ["CF", "LT"] (with the order being aribitrary).
+      example:
+        - "MS"
+      type: array
+    location:
+      readOnly: true
+      example:
+         - Kitchen
+      type: array
+      description: |
+        Similar to `type`, if all Devices in the Group are in the same Location,
+        this field will be an array with a single string. However, when Devices
+        from multiple Locations are combined in one Group, this field lists
+        each unique Location in arbitrary order.
+    actions:
+      readOnly: true
+      type: array
+      example:
+        - "Open"
+        - "Close"
+        - "Preset"
+      description: |
+        The list of available Actions on the Group.
+        This is the intersection of Actions for the Devices in the Group.
+        In other words, the Group Actions are those Actions which are common
+        to all Devices in the Group.
+    state:
+      readOnly: true
+      type: object
+      example:
+        _: "ad9bcde4"
+  required:
+  - name
+
+GroupDeletion:
+  properties:
+    devices:
+      type: array
+      example:
+        - "aabbccdd"
+
+GroupList:
+  type: object
+  example:
+    _: "7fc1e84b"
+    3b20f300:
+        _: "9a5e1136"
+    4caf6472:
+        _: "409d124b"
+State:
+  example:
+    open: 1

--- a/groups/schemas.yaml
+++ b/groups/schemas.yaml
@@ -8,7 +8,8 @@ Group:
       description: |
         List of member Device IDs.
 
-        This field is read-only. Use the Group Devices endpoint's PUT/DELETE
+        This field is read-only after group creation.
+        Use the Group Devices endpoint's POST/DELETE
         methods to add/remove Devides from the Group.
       type: array
       example:

--- a/groups/schemas.yaml
+++ b/groups/schemas.yaml
@@ -4,8 +4,12 @@ Group:
       example: Kitchen Shades
       type: string
     devices:
+      readOnly: true
       description: |
         List of member Device IDs.
+
+        This field is read-only. Use the Group Devices endpoint's PUT/DELETE
+        methods to add/remove Devides from the Group.
       type: array
       example:
         - "aabbccdd"
@@ -56,13 +60,6 @@ Group:
         _: "ad9bcde4"
   required:
   - name
-
-GroupDeletion:
-  properties:
-    devices:
-      type: array
-      example:
-        - "aabbccdd"
 
 GroupList:
   type: object

--- a/local.yaml
+++ b/local.yaml
@@ -24,9 +24,16 @@ x-tagGroups:
       - Device Commands
       - Device Command Signal
       - Device Command Transmit
+  - name: Groups
+    tags:
+      - Groups
+      - Group State
+      - Group Properties
+      - Group Actions
   - name: Schedules
     tags:
       - Device Schedules
+      - Group Schedules
   - name: Bridge
     tags:
       - Bridge

--- a/local.yaml
+++ b/local.yaml
@@ -27,6 +27,7 @@ x-tagGroups:
   - name: Groups
     tags:
       - Groups
+      - Group Devices
       - Group State
       - Group Properties
       - Group Actions

--- a/local.yaml
+++ b/local.yaml
@@ -31,10 +31,17 @@ x-tagGroups:
       - Group State
       - Group Properties
       - Group Actions
+  - name: Scenes
+    tags:
+      - Scenes
+      - Scene Devices
+      - Scene State
+      - Scene Actions
   - name: Schedules
     tags:
       - Device Schedules
       - Group Schedules
+      - Scene Schedules
   - name: Bridge
     tags:
       - Bridge

--- a/local/paths.yaml
+++ b/local/paths.yaml
@@ -39,6 +39,20 @@
     $ref: ../skeds/paths.yaml#/SkedsPath
 /v2/devices/{device_id}/skeds/{sked_id}:
     $ref: ../skeds/paths.yaml#/SkedPath
+/v2/groups:
+    $ref: ../groups/paths.yaml#/GroupsPath
+/v2/groups/{group_id}:
+    $ref: ../groups/paths.yaml#/GroupPath
+/v2/groups/{group_id}/state:
+    $ref: ../groups/paths.yaml#/StatePath
+/v2/groups/{groups_id}/properties:
+    $ref: ../groups/paths.yaml#/PropertiesPath
+/v2/groups/{group_id}/actions/{action_name}:
+    $ref: ../actions/group-paths.yaml#/ActionPath
+/v2/groups/{group_id}/skeds:
+    $ref: ../skeds/group-paths.yaml#/SkedsPath
+/v2/groups/{group_id}/skeds/{sked_id}:
+    $ref: ../skeds/group-paths.yaml#/SkedPath
 /v2/signal/tx:
     $ref: ../signal/paths.yaml#/TxPath
 /v2/signal/rssi:

--- a/local/paths.yaml
+++ b/local/paths.yaml
@@ -43,6 +43,10 @@
     $ref: ../groups/paths.yaml#/GroupsPath
 /v2/groups/{group_id}:
     $ref: ../groups/paths.yaml#/GroupPath
+/v2/groups/{group_id}/devices:
+    $ref: ../groups/paths.yaml#/DevicesPath
+/v2/groups/{group_id}/devices/{device_id}:
+    $ref: ../groups/paths.yaml#/DevicePath
 /v2/groups/{group_id}/state:
     $ref: ../groups/paths.yaml#/StatePath
 /v2/groups/{group_id}/properties:

--- a/local/paths.yaml
+++ b/local/paths.yaml
@@ -45,7 +45,7 @@
     $ref: ../groups/paths.yaml#/GroupPath
 /v2/groups/{group_id}/state:
     $ref: ../groups/paths.yaml#/StatePath
-/v2/groups/{groups_id}/properties:
+/v2/groups/{group_id}/properties:
     $ref: ../groups/paths.yaml#/PropertiesPath
 /v2/groups/{group_id}/actions/{action_name}:
     $ref: ../actions/group-paths.yaml#/ActionPath

--- a/local/paths.yaml
+++ b/local/paths.yaml
@@ -57,6 +57,22 @@
     $ref: ../skeds/group-paths.yaml#/SkedsPath
 /v2/groups/{group_id}/skeds/{sked_id}:
     $ref: ../skeds/group-paths.yaml#/SkedPath
+/v2/scenes:
+    $ref: ../scenes/paths.yaml#/ScenesPath
+/v2/scenes/{scene_id}:
+    $ref: ../scenes/paths.yaml#/ScenePath
+/v2/scenes/{scene_id}/devices:
+    $ref: ../scenes/paths.yaml#/DevicesPath
+/v2/scenes/{scene_id}/devices/{device_id}:
+    $ref: ../scenes/paths.yaml#/DevicePath
+/v2/scenes/{scene_id}/state:
+    $ref: ../scenes/paths.yaml#/StatePath
+/v2/scenes/{scene_id}/actions/{action_name}:
+    $ref: ../actions/scene-paths.yaml#/ActionPath
+/v2/scenes/{scene_id}/skeds:
+    $ref: ../skeds/scene-paths.yaml#/SkedsPath
+/v2/scenes/{scene_id}/skeds/{sked_id}:
+    $ref: ../skeds/scene-paths.yaml#/SkedPath
 /v2/signal/tx:
     $ref: ../signal/paths.yaml#/TxPath
 /v2/signal/rssi:

--- a/scenes/paths.yaml
+++ b/scenes/paths.yaml
@@ -1,0 +1,316 @@
+ScenesPath:
+  get:
+    description: |
+      Returns a list of Scene IDs and the corresponding Scene hashes.
+      The hashes change if any part of the Scene (its name, state, type, etc.)
+      has changed. The hash is not updated if underlying Devices or Groups
+      are updated in a way which does not effect the Scene state or type.
+
+      Scenes are only supported on Bond Bridges, not on Smart by Bond.
+      Furthermore, Scenes may only include Devices and Groups on the same Bridge.
+    responses:
+      '200':
+        content:
+          application/json:
+            schema:
+              $ref: schemas.yaml#/SceneList
+        description: List Scenes
+      '401':
+        $ref: ../common/responses.yaml#/Unauthorized
+      '500':
+        $ref: ../common/responses.yaml#/InternalServerError
+    security:
+      - OAuth: ["oauth2"]
+    summary: List your Scenes
+    tags:
+    - Scenes
+  post:
+    requestBody:
+      content:
+        application/json:
+          schema:
+            $ref: ../scenes/schemas.yaml#/Scene
+    responses:
+      '201':
+        $ref: ../common/responses.yaml#/Created
+      '400':
+        $ref: ../common/responses.yaml#/BadRequest
+      '401':
+        $ref: ../common/responses.yaml#/Unauthorized
+      '409':
+        $ref: ../common/responses.yaml#/Conflict
+      '500':
+        $ref: ../common/responses.yaml#/InternalServerError
+    summary: Create new Scene
+    description: |
+      For the creation of a Scene distributed across multiple Bonds,
+      clients should generate a random 64-bit ID for the Scene and provide that
+      same ID in each Scene POST request in the `_id` field. If the `_id`
+      field is not provided, a random ID will be assigned as with
+      POST requests to other enumerations.
+
+      If `devices` is not provided, an empty Scene is created.
+      If `devices` is an array of arrays of the form `[ID, action,
+      argument]`, then a Scene is created
+      containing those device actions. Using the `devices` field requires
+      the client to predetermine what devices are compatible in the sense
+      of having a non-empty Actions intersection. For this reason, it is
+      simpler for the client to make individual Scenes Devices POSTs for each
+      device to be added to the Scene, so that the Bond firmware may provide
+      a 400 error in case a device cannot be added due to incompatability.
+    tags:
+    - Scenes
+
+ScenePath:
+  get:
+    $ref: ../scenes/paths.yaml#/Get
+  parameters:
+    - in: path
+      name: scene_id
+      required: true
+      schema:
+        type: number
+  patch:
+    $ref: ../scenes/paths.yaml#/Patch
+  delete:
+    $ref: ../scenes/paths.yaml#/Delete
+
+DevicesPath:
+  post:
+    $ref: ../scenes/paths.yaml#/DevicesPost
+
+DevicePath:
+  delete:
+    $ref: ../scenes/paths.yaml#/DeviceDelete
+
+StatePath:
+  get:
+    $ref: ../scenes/paths.yaml#/GetState
+  parameters:
+  - in: path
+    name: scene_id
+    required: true
+    schema:
+      type: number
+GetList:
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            $ref: schemas.yaml#/SceneList
+      description: List active Scenes
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  security:
+    - OAuth: ["oauth2"]
+  summary: List your Scenes
+  tags:
+  - Scenes
+Post:
+  requestBody:
+    content:
+      application/json:
+        schema:
+          required: true
+          $ref: schemas.yaml#/Scene
+  responses:
+    '201':
+      $ref: ../common/responses.yaml#/Created
+    '400':
+      $ref: ../common/responses.yaml#/BadRequest
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '409':
+      $ref: ../common/responses.yaml#/Conflict
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  summary: Create new Scene
+  tags:
+  - Scenes
+Get:
+  description: |
+    Scenes are collections of Devices on a single Bridge.
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            required: true
+            $ref: schemas.yaml#/Scene
+      description: Get Scene
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  security:
+    - OAuth: ["oauth2"]
+  summary: Get Scene
+  tags:
+  - Scenes
+Patch:
+  requestBody:
+    content:
+      application/json:
+        schema:
+          required: true
+          $ref: schemas.yaml#/Scene
+          type: object
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            $ref: schemas.yaml#/Scene
+      description: Change Scene field
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  security:
+  - BasicAuth: []
+  summary: Change Scene field
+  description: |
+    To add or remove Devices from the Scene,
+    use the Scene Devices endpoint's PUT and DELETE methods instead of this one.
+  tags:
+  - Scenes
+Delete:
+  responses:
+    '204':
+      description: Delete Scene
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  security:
+  - BasicAuth: []
+  summary: Delete Scene
+  description: |
+    The entire Scene is deleted.
+  tags:
+  - Scenes
+
+DevicesPost:
+  parameters:
+  - in: path
+    name: scene_id
+    required: true
+    schema:
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          properties:
+            device:
+              example: "aabbccdd"
+              type: string
+              description: |
+                ID of Device or Group to add
+            action:
+              example: "SetSpeed"
+              type: string
+              description: |
+                Action to run on Device or Group
+            argument:
+              example: "2"
+              type: string
+              description: |
+                Argument for Action, if required. (JSON rendered as string)
+            order:
+              example: 10000
+  responses:
+    '204':
+      description: Add Device to Scene
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  security:
+  - BasicAuth: []
+  summary: Add Device to Scene
+  description: |
+    Device or Group with the specified ID is added to the Scene.
+
+    A gratuitous update of the corresponding Scene endpoint will occur
+    to update clients as to the new devices, actions, state, and properties.
+  tags:
+  - Scene Devices
+
+DeviceDelete:
+  parameters:
+  - in: path
+    name: scene_id
+    required: true
+    schema:
+      type: string
+  - in: path
+    name: device_id
+    required: true
+    schema:
+      type: string
+  responses:
+    '204':
+      description: Remove Device from Scene
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  security:
+  - BasicAuth: []
+  summary: Remove Device from Scene
+  description: |
+    Device or Group with the ID specified in the URL is removed from the Scene.
+
+    A gratuitous update of the corresponding Scene endpoint will occur
+    to update clients as to the new devices, actions, state, and properties.
+  tags:
+  - Scene Devices
+
+GetState:
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            $ref: schemas.yaml#/State
+      description: Get Scene State
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  security:
+    - OAuth: ["oauth2"]
+  summary: Get Scene State
+  description: |
+    Scene State has just a single member variable `active`.
+
+    After Activating a Scene, the `active` variable is set to `true`.
+    Any further actions called on any member Devices or Groups will cause `active`
+    to change to `false`. This occurs even if the Device Action did not cause
+    the device's state to change. Furthermore, the Scene's `active` variable
+    will not become `true` as a result of independent Device State changes,
+    even if Devices enter a state that they would reach after Scene activation.
+
+    The purpose of the `active` variable is simply to show a persistent feedback
+    to the user of an integration that the Scene was successfully activated.
+    Multiple Scenes may show as activated, but only if they have no mutual Devices.
+
+    Note that Scene states cannot be PATCHed.
+  tags:
+  - Scene State

--- a/scenes/schemas.yaml
+++ b/scenes/schemas.yaml
@@ -1,0 +1,111 @@
+Scene:
+  properties:
+    name:
+      example: Movie Time
+      type: string
+    devices:
+      readOnly: true
+      description: |
+        List of member Device IDs.
+
+        This field is read-only after scene creation.
+        Use the Scene Devices endpoint's POST/DELETE
+        methods to add/remove Devices and Groups from the Scene,
+        or the PATCH endpoint to change the Action or Argument,
+        or to change the execution order.
+      type: array
+      example:
+        - ["aabbccdd", "TurnLightOff", ""]
+        - ["11223344", "SetSpeed", "1"]
+        - ["deadbeef", "Close", ""]
+    type:
+      readOnly: true
+      description: |
+        For values, see `type` field of Device schema.
+
+        Type is automatically set by the Bond Bridge to be the type of the
+        underlying devices when all devices are of the same type. Note that
+        Scene type is always an array, even if it has zero or one element.
+
+        When devies of multiple types are mixed in a single Scene,
+        this `type` lists each type.
+        For example, a Ceiling Fan (CF) and a Light (LT) combined would be
+        ["CF", "LT"] (with the order being aribitrary).
+      example:
+        - "MS"
+      type: array
+    location:
+      readOnly: true
+      example:
+         - Kitchen
+      type: array
+      description: |
+        Similar to `type`, if all Devices in the Scene are in the same Location,
+        this field will be an array with a single string. However, when Devices
+        from multiple Locations are combined in one Scene, this field lists
+        each unique Location in arbitrary order.
+    actions:
+      readOnly: true
+      type: array
+      example:
+        - "Activate"
+      description: |
+        Scenes always have exactly one action called "Activate".
+    state:
+      readOnly: true
+      type: object
+      example:
+        _: "ad9bcde4"
+        "active": true
+  required:
+  - name
+
+SceneList:
+  type: object
+  example:
+    _: "7fc1e84b"
+    3b20f300:
+        _: "9a5e1136"
+    4caf6472:
+        _: "409d124b"
+State:
+  example:
+    active: true
+
+SceneDevice:
+  properties:
+    device:
+      example: "aabbccdd"
+      type: string
+      description: |
+        ID of Device or Group.
+    action:
+      example: "SetSpeed"
+      type: string
+      description: |
+        Action to run on Device or Group
+    argument:
+      example: "2"
+      type: string
+      description: |
+        Argument for Action, if required. (JSON rendered as string)
+    order:
+      example: 10000
+      type: integer
+      description: |
+        If not provided, order of a new Scene Device is the highest
+        order of other Scene Devices plus 10000.
+
+        When activating a Scene, Bond Bridge executes device actions
+        with lowest order first. This order is only ensured within a single
+        Bridge. For Scenes that span multiple Bridges, Scenes including SBB
+        devices, some concurrent execution will occur.
+
+        The order should be used by the client to enforce display order
+        in Scene editing. However, care should be taken with this UX
+        when multiple Bonds are involved, due to the concurrent execution
+        and irrelevence of the order in that case.
+
+        (32-bit unsigned integer)
+  required:
+  - devices

--- a/skeds/group-paths.yaml
+++ b/skeds/group-paths.yaml
@@ -1,0 +1,140 @@
+SkedsPath:
+  parameters:
+  - in: path
+    name: group_id
+    required: true
+    schema:
+      type: string
+  get:
+    $ref: ../skeds/group-paths.yaml#/GetList
+  post:
+    $ref: ../skeds/group-paths.yaml#/Post
+
+SkedPath:
+  parameters:
+  - in: path
+    name: group_id
+    required: true
+    schema:
+      type: string
+  - in: path
+    name: sked_id
+    required: true
+    schema:
+      type: string
+  get:
+    $ref: ../skeds/group-paths.yaml#/Get
+  patch:
+    $ref: ../skeds/group-paths.yaml#/Patch
+  delete:
+    $ref: ../skeds/group-paths.yaml#/Delete
+
+Post:
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: schemas.yaml#/Sked
+  responses:
+    '201':
+      $ref: ../common/responses.yaml#/Created
+    '400':
+      $ref: ../common/responses.yaml#/BadRequest
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  summary: Create new Group Schedule
+  description: |
+    Creates a Group Schedule under a specific Group.
+
+    If the timezone or location settings in `sys/time` are not set,
+    a 400 error may result depending on what `mark` is requested.
+    Specifically, the following requests will result in an 400 error:
+
+       - POSTed `mark` is `midnight` but `sys/time.tz` is `null`
+       - POSTed `mark` is `dawn`, `dusk`, `sunrise`, or `sunset`, but `sys/time.grid` is `null`
+
+  tags:
+  - Group Schedules
+
+Patch:
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: schemas.yaml#/Sked
+  responses:
+    '200':
+      description: Group Schedule modified
+    '400':
+      $ref: ../common/responses.yaml#/BadRequest
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  summary: Modify an existing Group Schedule
+  description: |
+    Modifies any fields of an existing Group Schedule.
+  tags:
+  - Group Schedules
+
+GetList:
+  description: |
+    Returns a list of sked_ids and the corresponding sked hashes.
+    Please see the "Hash Tree" documentation for an explanation of hashes.
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            $ref: schemas.yaml#/SkedList
+      description: Group Schedule list returned
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  summary: Get list of Group Schedules
+  tags:
+  - Group Schedules
+
+Get:
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            $ref: schemas.yaml#/Sked
+      description: Group Schedule object returned
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  summary: Get specific Group Schedule
+  description: |
+    Get information about a Group Schedule.
+  tags:
+  - Group Schedules
+
+Delete:
+  responses:
+    '204':
+      description: Group Schedule deleted
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  summary: Delete a Group Schedule
+  description: |
+    Deletes specified Group Schedule.
+    Naturally, the Group Schedule will be canceled.
+  tags:
+  - Group Schedules

--- a/skeds/scene-paths.yaml
+++ b/skeds/scene-paths.yaml
@@ -1,0 +1,142 @@
+SkedsPath:
+  parameters:
+  - in: path
+    name: scene_id
+    required: true
+    schema:
+      type: string
+  get:
+    $ref: ../skeds/scene-paths.yaml#/GetList
+  post:
+    $ref: ../skeds/scene-paths.yaml#/Post
+
+SkedPath:
+  parameters:
+  - in: path
+    name: scene_id
+    required: true
+    schema:
+      type: string
+  - in: path
+    name: sked_id
+    required: true
+    schema:
+      type: string
+  get:
+    $ref: ../skeds/scene-paths.yaml#/Get
+  patch:
+    $ref: ../skeds/scene-paths.yaml#/Patch
+  delete:
+    $ref: ../skeds/scene-paths.yaml#/Delete
+
+Post:
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: schemas.yaml#/Sked
+  responses:
+    '201':
+      $ref: ../common/responses.yaml#/Created
+    '400':
+      $ref: ../common/responses.yaml#/BadRequest
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  summary: Create new Scene Schedule
+  description: |
+    Creates a Scene Schedule under a specific Scene.
+
+    The action must be "Activate" and the argument must be empty.
+
+    If the timezone or location settings in `sys/time` are not set,
+    a 400 error may result depending on what `mark` is requested.
+    Specifically, the following requests will result in an 400 error:
+
+       - POSTed `mark` is `midnight` but `sys/time.tz` is `null`
+       - POSTed `mark` is `dawn`, `dusk`, `sunrise`, or `sunset`, but `sys/time.grid` is `null`
+
+  tags:
+  - Scene Schedules
+
+Patch:
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: schemas.yaml#/Sked
+  responses:
+    '200':
+      description: Scene Schedule modified
+    '400':
+      $ref: ../common/responses.yaml#/BadRequest
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  summary: Modify an existing Scene Schedule
+  description: |
+    Modifies any fields of an existing Scene Schedule.
+  tags:
+  - Scene Schedules
+
+GetList:
+  description: |
+    Returns a list of sked_ids and the corresponding sked hashes.
+    Please see the "Hash Tree" documentation for an explanation of hashes.
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            $ref: schemas.yaml#/SkedList
+      description: Scene Schedule list returned
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  summary: Get list of Scene Schedules
+  tags:
+  - Scene Schedules
+
+Get:
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            $ref: schemas.yaml#/Sked
+      description: Scene Schedule object returned
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  summary: Get specific Scene Schedule
+  description: |
+    Get information about a Scene Schedule.
+  tags:
+  - Scene Schedules
+
+Delete:
+  responses:
+    '204':
+      description: Scene Schedule deleted
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  summary: Delete a Scene Schedule
+  description: |
+    Deletes specified Scene Schedule.
+    Naturally, the Scene Schedule will be canceled.
+  tags:
+  - Scene Schedules


### PR DESCRIPTION
Possibly controversial aspects of Scenes API proposal:

 - Groups can also be added to Scenes (I think this will be very useful with shade groups.)
 - Despite that, the endpoint is still `scenes/x/devices/y` not `scenes/x/devices_and_or_groups/y`.
 - Maybe it should be `scenes/x/device_actions/y` instead, since it's not just devices here. 🤔 
 - Device may be provided on the POST to `scenes`, but this is not recommended because the 400 error will not be very helpful. Adding Devices one at a time would provide more useful error feedback.
 - An `order` parameter in device actions, to enforce order of operations on the Bridge. Important for some ceiling fans.
 - There's no delay action. Actions will execute as fast as possible given the RF constraints.
 - No way to enforce order with Scenes that are distributed across Bridges / SBBs.