### PR TITLE
PowerCycleState

### DIFF
--- a/devices/paths.yaml
+++ b/devices/paths.yaml
@@ -179,6 +179,114 @@ PatchProperties:
   tags:
   - Device Properties
 
+PowerCycleStatePath:
+  get:
+    $ref: ../devices/paths.yaml#/GetPowerCycleState
+  patch:
+    $ref: ../devices/paths.yaml#/PatchPowerCycleState
+  delete:
+    $ref: ../devices/paths.yaml#/DeletePowerCycleState
+  parameters:
+  - in: path
+    name: device_id
+    required: true
+    schema:
+      type: number
+
+PatchPowerCycleState:
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: schemas.yaml#/PowerCycleState
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            $ref: schemas.yaml#/PowerCycleState
+      description: Power Cycle State updated
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  security:
+    - OAuth: ["oauth2"]
+  summary: Update Power Cycle State
+  tags:
+  - Power Cycle State
+
+GetPowerCycleState:
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            $ref: schemas.yaml#/PowerCycleState
+      description: Current Power Cycle State
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  security:
+    - OAuth: ["oauth2"]
+  summary: Read Power Cycle State
+  description: |
+    This feature is intended to be used with smart Ceiling Fan receivers
+    that are connected to "dumb" wall switches. Many users have existing
+    non-smart ceiling fans which are connected to non-smart wall switches.
+    These non-smart ceiling fans typically have some pull switches where
+    the user can set the desired state, and then the wall switch is used
+    as the means of operating the device. For example, the ceiling fan may
+    be the primary light source in the room, and the user relies on the wall
+    switch as a normal light switch. When they then make the fan smart
+    by adding a Smart By Bond receiver to the fan, they expect that they
+    can continue to use the wall switch. A problem arises when the user
+    turns off the fan light using the API (Alexa, app, etc.) and then
+    enters the room and attempts to operate using the wall switch. The fan
+    will remain in the state with light off. The Power On State feature allows
+    users to guarantee a prefered state every time the device powers on,
+    making it easier to use in a situation where the wall switch is relied upon.
+
+    This feature is only available on certain SBB products where it makes sense,
+    specifically all ceiling fans. We have not enabled it on in-wall switches
+    and dimmers and other SBB products where there is only a power supply
+    or circuit breaker behind the product, rather than there possibly being
+    a user-facing "dumb" wall switch.
+
+    [SBB-only, added in v2.17]
+  tags:
+  - Power Cycle State
+
+DeletePowerCycleState:
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            $ref: schemas.yaml#/PowerCycleState
+      description: Power Cycle State restored to factory default
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  security:
+    - OAuth: ["oauth2"]
+  summary: Set Power Cycle State to defaults
+  description: |
+    Deleting the Power Cycle State for a Device will cause it to revert
+    to the default as programmed from the factory. This is typically
+    a disabled state. For most API clients, it makes more sense to use
+    PATCH rather than DELETE.
+  tags:
+  - Power Cycle State
+
 GetList:
   responses:
     '200':

--- a/devices/schemas.yaml
+++ b/devices/schemas.yaml
@@ -11,12 +11,12 @@ Device:
         - `GX` : Generic device
         - `LT` : Light
         - `BD` : Bidet
-        
+
         This `type` field does not impact the functionality of the device.
         The `type` field should be used by API clients to improve the user experience.
         For example, the Bond Home app uses this field to determine what icon to show
         when browsing a list of Devices on the Bridge.
-        
+
         The `type` field *may* be used by integrations to determine the category of interface to be selected
         when such a selection is mandated by the platform. For example, Google Assistant integration
         requires developers to choose a device type such as Fan or Light.
@@ -27,24 +27,24 @@ Device:
     subtype:
       description: |
         [Added in v2.21]
-        
+
         The subtype field is used to distinguish between categories of devices sublter than the `type` field permits.
-        
+
         Currently, subtype is only used for Motorized Window Coverings and Awnings (`type = MS`), with the following options:
-        
+
          - `ROLLER`: a roller blackout shade which blocks light and provides privacy
          - `SHEER`: a shade which permits light to pass and does not provide privacy
          - `AWNING`: an outdoor patio covering
-         
+
         This field does not impact functionality in any way.
         Furthermore, the `subtype` field must only be used for analytics and aesthetic purposes by the API client.
         New subtypes may be introduced without notice. API clients should always be prepared to fall back to a reasonable
         default based on the device `type`.
-         
+
         The `subtype` field is not limited by the firmware, but rather specified by Bond internally and included
         in Device creation requests from the Bond Home app.
-        
-        WARNING: Although currently it is not the case, at some point the same `subtype` string may be re-used with 
+
+        WARNING: Although currently it is not the case, at some point the same `subtype` string may be re-used with
         different meanings between different device `types`. To take a hypothetical example, we may have a gas-powered
         fireplace device (`type = FP, subtype = GAS`) but also a gas-powered bidet (`type = BD, subtype = GAS`).
       example: "AWNING"
@@ -145,6 +145,22 @@ Properties:
       example: 30
       type: integer
       description: (Bridge-only)
+
+PowerCycleState:
+  properties:
+    enabled:
+      example: false
+      type: boolean
+      description: |
+        If true, device will revert to specified state after power loss.
+        If false, device will maintain previous state across power loss
+        ("Last State" feature).
+    state:
+      example: {"light": 1, "brightness": 100, "power": 0, "speed": 3}
+      type: object
+      description: |
+        State to revert to after power loss.
+        Same schema as for Device state.
 
 Bridge:
   properties:

--- a/local.yaml
+++ b/local.yaml
@@ -19,6 +19,7 @@ x-tagGroups:
       - Device Actions
       - Device Remote Address
       - Device Reload
+      - Power Cycle State
   - name: Commands
     tags:
       - Device Commands

--- a/local/paths.yaml
+++ b/local/paths.yaml
@@ -25,6 +25,8 @@
     $ref: ../devices/paths.yaml#/ReloadPath
 /v2/devices/{device_id}/properties:
     $ref: ../devices/paths.yaml#/PropertiesPath
+/v2/devices/{device_id}/power_cycle_state:
+    $ref: ../devices/paths.yaml#/PowerCycleStatePath
 /v2/devices/{device_id}/actions/{action_name}:
     $ref: ../actions/paths.yaml#/ActionPath
 /v2/devices/{device_id}/commands:


### PR DESCRIPTION
We realized at Scrum call this morning that this documentation was missing.


<img width="1605" alt="Screen Shot 2021-12-22 at 09 56 35" src="https://user-images.githubusercontent.com/628921/147111826-379bde18-489b-47e3-8b68-6eaae8c51d6f.png">


<img width="1605" alt="Screen Shot 2021-12-22 at 09 57 06" src="https://user-images.githubusercontent.com/628921/147111893-c7610776-2443-4790-9300-2b6258d1eb59.png">


<img width="1588" alt="Screen Shot 2021-12-22 at 09 57 20" src="https://user-images.githubusercontent.com/628921/147111918-de96d2b8-5e75-4b5a-ba18-0dc3aeaa4aec.png">

