### PR TITLE
Position: open_position property

### DIFF
--- a/common/info.yaml
+++ b/common/info.yaml
@@ -939,11 +939,15 @@ description: |
 
   ### Properties
 
-  (none)
+   - **open_position**: (bool) (read-only) [added in v2.30.1] if true, then `position`
+     describes the "open percentage".
+     If false or not present, then a "closed percentage" is described.
 
   ### State Variables
 
-   - **position**: (integer) value from 0 to 100: 0 = open, 100 = closed.
+   - **position**: (integer) value from 0 to 100: 0 = closed, 100 = open.
+     (Unless `open_position` is false or absent, in which case
+     0 = open, 100 = closed).
 
   ### Actions
 
@@ -965,6 +969,9 @@ description: |
   non-negative value before the actions and state variables will be exposed,
   so as to avoid integrations from showing a slider interface without
   the Bridge having the capability of setting position.
+
+  [January 2022] In v2.30.1, we made a switch to "open percentage" to
+  align with smart shade UIs in HomeKit, Crestron Home, and others.
 
   ## CourseTime
 

--- a/common/info.yaml
+++ b/common/info.yaml
@@ -939,10 +939,7 @@ description: |
 
   ### Properties
 
-   - **course_time**: (integer) specifies the amount of time, in milliseconds,
-     required for the device to fully open or close. Depending on the device
-     template, this property may or may not be present. Defaults to -1,
-     meaning unconfigured.
+  (none)
 
   ### State Variables
 
@@ -968,6 +965,31 @@ description: |
   non-negative value before the actions and state variables will be exposed,
   so as to avoid integrations from showing a slider interface without
   the Bridge having the capability of setting position.
+
+  ## CourseTime
+
+  The CourseTime feature is used for shades whose RF protocols
+  do not natively support Position. Bond Bridge Pro emulates
+  a Position feature using a custom dead reckoning algorithm.
+  This requires the client to specify the time required for the
+  shade to open or close.
+
+  The CourseTime feature requires the Position feature.
+
+  ### Properties
+
+   - **course_time**: (integer) specifies the amount of time, in milliseconds,
+     required for the device to fully open or close. Depending on the device
+     template, this property may or may not be present. Defaults to -1,
+     meaning unconfigured.
+
+  ### State Variables
+
+  (none)
+
+  ### Actions
+
+  (none)
 
   ## FpFan
 


### PR DESCRIPTION
Switch to open percentage to align with industry standard (HomeKit, Crestron Home, and others).