### PR TITLE
Fix Network Watchdog endpoint

### DIFF
--- a/common/paths.yaml
+++ b/common/paths.yaml
@@ -144,7 +144,7 @@
 /v2/sys/wifi/scan:
   get:
     $ref: ../network/paths.yaml#/ScanGet
-/v2/sys/watchdog:
+/v2/sys/wifi/watchdog:
   get:
     $ref: ../network/paths.yaml#/WatchdogGet
   patch:

--- a/local/paths.yaml
+++ b/local/paths.yaml
@@ -77,10 +77,10 @@
   $ref: ../network/paths.yaml#/WifiScanPath
 /v2/sys/wifi/sta:
   $ref: ../network/paths.yaml#/WifiStaPath
+/v2/sys/wifi/watchdog:
+  $ref: ../network/paths.yaml#/WifiWatchDogPath
 /v2/sys/eth:
   $ref: ../network/paths.yaml#/EthPath
-/v2/sys/watchdog:
-  $ref: ../network/paths.yaml#/WifiWatchDogPath
 /v2/sys/upgrade:
   $ref: ../network/paths.yaml#/WifiUpgradePath
 /v2/sys/version:


### PR DESCRIPTION
was sys/watchdog, but should be sys/wifi/watchdog as pointed out by [Matt at Forum](https://forum.bondhome.io/t/watchdog-api-endpoint-and-running-locally/2867/2)