### PR TITLE
Document Sidekick learn API enhancements (v4.24+)

### DIFF
--- a/sidekicks/paths.yaml
+++ b/sidekicks/paths.yaml
@@ -261,8 +261,12 @@ LearnGet:
     Provides information about the Sidekick learn window on this Bond.
 
     When the learn window is open, the Bond will listen for a link intent.
-    Specifically, it listens for a BondSync message of type LINK or 
+    Specifically, it listens for a BondSync message of type LINK or
     type KEYSTREAM with HOLD event and duration greater than 2 seconds.
+
+    The `new_id` field shows the ID of any newly learned Sidekick. This field
+    is cleared when opening a new learn window to prevent showing stale data
+    from previous learn sessions.
 
     [New in v3.10]
   tags:
@@ -293,6 +297,18 @@ LearnPatch:
     Open/close the learn window.
 
     The learn window is never automatically opened. Must be opened by API.
+
+    ### Device Filtering
+
+    The optional `pattern` field allows filtering which Sidekick devices can be
+    learned during the window. This prevents incompatible devices from pairing
+    to the wrong product type.
+
+    Example use cases:
+    - Set `pattern: "^SM"` to accept only Mate remotes (IDs starting with SM)
+    - Omit the `pattern` field to accept all device types (backward compatible)
+
+    The pattern accepts regex syntax with a maximum length of 32 characters.
   tags:
   - Sidekick Learn
 

--- a/sidekicks/paths.yaml
+++ b/sidekicks/paths.yaml
@@ -266,7 +266,7 @@ LearnGet:
 
     The `new_id` field shows the ID of any newly learned Sidekick. This field
     is cleared when opening a new learn window to prevent showing stale data
-    from previous learn sessions.
+    from previous learn sessions. [v4.24+]
 
     [New in v3.10]
   tags:
@@ -298,7 +298,7 @@ LearnPatch:
 
     The learn window is never automatically opened. Must be opened by API.
 
-    ### Device Filtering
+    ### Device Filtering [v4.24+]
 
     The optional `pattern` field allows filtering which Sidekick devices can be
     learned during the window. This prevents incompatible devices from pairing

--- a/sidekicks/schemas.yaml
+++ b/sidekicks/schemas.yaml
@@ -180,7 +180,7 @@ Learn:
       type: string
       readOnly: true
       description: |
-        ID of the newly learned Sidekick, if any.
+        [v4.24+] ID of the newly learned Sidekick, if any.
         This field is cleared when opening a new learn window.
         Populated when a new Sidekick successfully links during the learn window.
     pattern:
@@ -189,7 +189,7 @@ Learn:
       writeOnly: true
       maxLength: 32
       description: |
-        Optional regex pattern to filter devices during learning (max 32 characters).
+        [v4.24+] Optional regex pattern to filter devices during learning (max 32 characters).
         Only devices whose IDs match this pattern will be accepted during the learn window.
         Example: "^SM" accepts only Mate devices (IDs starting with SM).
         If not specified, all device types are accepted (backward compatible).

--- a/sidekicks/schemas.yaml
+++ b/sidekicks/schemas.yaml
@@ -175,3 +175,21 @@ Learn:
         Number of times a new Sidekick has been learned on this boot.
         Useful in UI design to know that the learn process completed,
         even if the learned address is the same.
+    new_id:
+      example: "SMXXX12345"
+      type: string
+      readOnly: true
+      description: |
+        ID of the newly learned Sidekick, if any.
+        This field is cleared when opening a new learn window.
+        Populated when a new Sidekick successfully links during the learn window.
+    pattern:
+      example: "^SM"
+      type: string
+      writeOnly: true
+      maxLength: 32
+      description: |
+        Optional regex pattern to filter devices during learning (max 32 characters).
+        Only devices whose IDs match this pattern will be accepted during the learn window.
+        Example: "^SM" accepts only Mate devices (IDs starting with SM).
+        If not specified, all device types are accepted (backward compatible).


### PR DESCRIPTION
## Summary

Documents API changes from firmware PR ZolibraBond/bond-core#3401 for Sidekick learn endpoints:

- **New `new_id` field**: Shows ID of newly learned Sidekick; now properly cleared when opening new learn window (bugfix)
- **New `pattern` field**: Regex pattern for filtering devices during learning to prevent cross-product pairing (e.g., `"^SM"` for Mate remotes only)
- Updated endpoint descriptions with usage examples and backward compatibility notes
- All new features marked with [v4.24+]

## Changes

- `sidekicks/schemas.yaml`: Added `new_id` and `pattern` fields to `Learn` schema
- `sidekicks/paths.yaml`: Enhanced `LearnGet` and `LearnPatch` endpoint documentation

## Test plan

- [ ] Review schema definitions for correctness
- [ ] Verify examples match expected device ID patterns
- [ ] Confirm backward compatibility notes are clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)