### PR TITLE
Add /v2/transformer endpoint for PLC transformer

### DIFF
--- a/devices/schemas.yaml
+++ b/devices/schemas.yaml
@@ -30,11 +30,18 @@ Device:
 
         The subtype field is used to distinguish between categories of devices sublter than the `type` field permits.
 
-        Currently, subtype is only used for Motorized Window Coverings and Awnings (`type = MS`), with the following options:
+        Currently, subtype is used for Motorized Window Coverings and Awnings (`type = MS`), with the following options:
 
          - `ROLLER`: a roller blackout shade which blocks light and provides privacy
          - `SHEER`: a shade which permits light to pass and does not provide privacy
          - `AWNING`: an outdoor patio covering
+
+        For Light devices (`type = LT`), the subtype field can be:
+         - `MD`: Medium Accent
+         - `LG`: Large Accent
+         - `WL`: Wall Wash
+         - `PT`: Path Light
+         - `GE`: Generic Device
 
         This field does not impact functionality in any way.
         Furthermore, the `subtype` field must only be used for analytics and aesthetic purposes by the API client.

--- a/local.yaml
+++ b/local.yaml
@@ -61,6 +61,9 @@ x-tagGroups:
   - name: Bridge
     tags:
       - Bridge
+  - name: Transformer
+    tags:
+      - Transformer
   - name: Signals
     tags:
       - Transmit

--- a/local/paths.yaml
+++ b/local/paths.yaml
@@ -11,6 +11,8 @@
     $ref: ../debug/beau.yaml
 /v2/bridge:
     $ref: ../bridge/paths.yaml
+/v2/transformer:
+    $ref: ../transformer/paths.yaml
 /v2/sys/locale:
     $ref: ../locale/paths.yaml
 /v2/devices:

--- a/transformer/paths.yaml
+++ b/transformer/paths.yaml
@@ -1,0 +1,100 @@
+get:
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            $ref: schemas.yaml#/Transformer
+      description: Get Transformer info
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  security:
+    - OAuth: ["oauth2"]
+  summary: Get Transformer info
+  description: |
+    Returns comprehensive transformer status including tap configuration,
+    PLC fixture count, current monitoring, fault status, and commissioning state.
+
+    This endpoint provides all information necessary for monitoring transformer
+    health and managing the commissioning workflow.
+  tags:
+  - Transformer
+
+patch:
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: schemas.yaml#/Transformer
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            $ref: schemas.yaml#/Transformer
+      description: Transformer configuration updated
+    '400':
+      $ref: ../common/responses.yaml#/BadRequest
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  security:
+  - BasicAuth: []
+  summary: Update Transformer configuration
+  description: |
+    Modify transformer settings. Patchable fields include:
+
+    - `name`: User-assigned transformer name
+    - `location`: User-assigned location
+    - `tap_mode`: Array of 3 tap modes ("legacy" or "plc")
+    - `current_limit_yellow_ma`: Soft current warning threshold
+    - `current_limit_red_ma`: Hard current shutdown threshold
+    - `commission_mode`: Enable/disable commissioning mode
+    - `commission_timeout_ms`: Commissioning auto-expire duration
+    - `auto_detect_start`: Trigger fixture auto-detection (set to true)
+
+    **Important notes:**
+
+    - When changing `tap_mode`, at least one tap must remain in `plc` mode
+      if any PLC fixtures are currently commissioned
+    - Setting `commission_mode` to `true` will shut off all taps except
+      the commissioning port
+    - Setting `auto_detect_start` to `true` requires `commission_mode` to be `true`
+    - Auto-detection results appear in read-only fields `detected_capability`
+      and `detected_current_ma`
+
+    All read-only fields are ignored if included in the PATCH request.
+  tags:
+  - Transformer
+
+delete:
+  responses:
+    '204':
+      description: Transformer settings reset to defaults
+    '401':
+      $ref: ../common/responses.yaml#/Unauthorized
+    '404':
+      $ref: ../common/responses.yaml#/NotFound
+    '500':
+      $ref: ../common/responses.yaml#/InternalServerError
+  security:
+  - BasicAuth: []
+  summary: Reset Transformer to factory defaults
+  description: |
+    Resets transformer configuration to factory default values.
+
+    **Warning:** This does not delete commissioned PLC fixtures (devices),
+    but it will reset tap modes, current limits, and other configuration
+    to default values.
+
+    To fully reset the transformer, you must also DELETE all PLC fixture
+    devices (device IDs 1-60) and legacy tap devices (device IDs 1001-1003).
+  tags:
+  - Transformer

--- a/transformer/paths.yaml
+++ b/transformer/paths.yaml
@@ -59,6 +59,7 @@ patch:
     - `commission_mode`: Enable/disable commissioning mode
     - `commission_timeout_ms`: Commissioning auto-expire duration
     - `auto_detect_start`: Trigger fixture auto-detection (set to true)
+    - `fault_reset`: Clear a latched fault (set to true). Returns 400 if no fault active.
 
     **Important notes:**
 
@@ -69,6 +70,9 @@ patch:
     - Setting `auto_detect_start` to `true` requires `commission_mode` to be `true`
     - Auto-detection results appear in read-only fields `detected_capability`
       and `detected_current_ma`
+    - During an active fault (overload_shutdown or overload_short), changes to
+      `tap_mode` and `commission_mode` are rejected with a 500 error. Reset the
+      fault first using `fault_reset`.
 
     All read-only fields are ignored if included in the PATCH request.
   tags:

--- a/transformer/schemas.yaml
+++ b/transformer/schemas.yaml
@@ -1,0 +1,151 @@
+Transformer:
+  properties:
+    name:
+      type: string
+      example: "Front Yard Transformer"
+      description: User-assigned name for the transformer
+    location:
+      type: string
+      example: "Outdoor"
+      description: User-assigned location
+    tap_mode:
+      type: array
+      items:
+        type: string
+        enum: ["legacy", "plc"]
+      minItems: 3
+      maxItems: 3
+      example: ["plc", "plc", "legacy"]
+      description: |
+        Mode configuration for each of the 3 output taps (indices 0-2).
+
+        - `legacy`: Relay-switched on/off for traditional landscape fixtures
+        - `plc`: Constant power with PLC commands for smart addressable fixtures
+
+        Note: If any PLC fixtures are commissioned, at least one tap must be set to `plc` mode.
+    fixture_count:
+      type: integer
+      readOnly: true
+      example: 12
+      description: |
+        Number of currently commissioned PLC fixtures (range 0-60).
+        This count represents fixtures that have been assigned addresses.
+    fixture_max:
+      type: integer
+      readOnly: true
+      example: 60
+      description: Maximum number of PLC fixtures supported by this transformer
+    current_ma:
+      type: integer
+      readOnly: true
+      example: 2400
+      description: |
+        Current total current draw across all taps in milliamps.
+        Updated continuously during operation.
+    current_limit_yellow_ma:
+      type: integer
+      example: 5000
+      description: |
+        Soft current limit threshold in milliamps.
+        When exceeded, fault status changes to "overload_yellow" as a warning.
+        System continues to operate.
+    current_limit_red_ma:
+      type: integer
+      example: 6000
+      description: |
+        Hard current limit threshold in milliamps.
+        When exceeded, taps shut down and fault status changes to "overload_red".
+    fault:
+      type: string
+      nullable: true
+      readOnly: true
+      enum: [null, "overload_yellow", "overload_red", "overload_hard"]
+      example: null
+      description: |
+        Current fault condition:
+
+        - `null`: No fault, normal operation
+        - `overload_yellow`: Approaching current limit (soft warning)
+        - `overload_red`: Over current limit, taps have shut down
+        - `overload_hard`: Hard fault detected (likely short circuit)
+    commission_mode:
+      type: boolean
+      example: false
+      description: |
+        Commissioning mode state. When set to `true`:
+
+        - Commissioning port is energized
+        - All other taps are shut off for safety
+        - Mode auto-expires after `commission_timeout_ms`
+
+        Used during fixture pairing and testing workflow.
+    commission_timeout_ms:
+      type: integer
+      example: 300000
+      description: |
+        Auto-expire timeout for commission_mode in milliseconds.
+        Default: 300000 (5 minutes)
+
+        After this duration, commission_mode automatically reverts to false
+        and normal tap operation resumes.
+    commission_remaining_ms:
+      type: integer
+      readOnly: true
+      example: 0
+      description: |
+        Milliseconds remaining before commission_mode automatically disables.
+        Returns 0 when commission_mode is false.
+    auto_detect_start:
+      type: boolean
+      example: false
+      description: |
+        Trigger auto-detection of fixture capabilities.
+
+        PATCH to `true` to start auto-detection process.
+        Requires `commission_mode` to be `true`.
+
+        The transformer will analyze the fixture connected to the commissioning
+        port and attempt to determine its capabilities and current draw.
+    auto_detect_busy:
+      type: boolean
+      readOnly: true
+      example: false
+      description: |
+        Indicates whether auto-detection is currently running.
+        When `true`, detection is in progress. When `false`, detection
+        has completed or has not been started.
+    detected_capability:
+      type: string
+      nullable: true
+      readOnly: true
+      enum: [null, "dimmable", "cct", "rgb", "rgbw", "rgbww"]
+      example: "rgbw"
+      description: |
+        Auto-detected fixture capability from most recent detection cycle.
+
+        - `null`: No fixture detected or detection not run
+        - `dimmable`: Dimmable white only
+        - `cct`: Tunable white (cool/warm)
+        - `rgb`: RGB color
+        - `rgbw`: RGB + warm white
+        - `rgbww`: RGB + warm white + cool white (5 channel)
+
+        This is a suggestion only. User may override during commissioning.
+    detected_current_ma:
+      type: integer
+      nullable: true
+      readOnly: true
+      example: 180
+      description: |
+        Detected current draw in milliamps from most recent auto-detection.
+        Returns `null` if no detection has been performed or no fixture detected.
+    next_available_device_id:
+      type: integer
+      readOnly: true
+      example: 13
+      description: |
+        Next available device ID for commissioning a new PLC fixture.
+        Range: 1-60
+
+        This is the device ID that will be assigned when the next fixture
+        is successfully commissioned via POST to /v2/devices.

--- a/transformer/schemas.yaml
+++ b/transformer/schemas.yaml
@@ -120,13 +120,13 @@ Transformer:
         Milliseconds remaining before commission_mode automatically disables.
         Returns 0 when commission_mode is false.
     commission_device_id:
-      type: integer
+      type: string
+      nullable: true
       readOnly: true
-      example: 13
+      example: "0000000d"
       description: |
-        Device ID of newly created PLC fixture.
-        Range: 1-60
-        Error: -1
+        Device ID (hex string) of newly created PLC fixture.
+        Null on error.
 
         App can then test fixture by using /v2/devices/{commission_device_id}
 
@@ -195,3 +195,7 @@ Transformer:
         2. Optionally PATCH /v2/transformer with custom commission_device_info
         3. PATCH commission_mode=true to start commissioning
         4. After commissioning succeeds, commission_device_info resets to defaults
+
+        **Note:** Commissioned PLC fixtures expose a `fixture_address` string property ("1"-"60")
+        at `/v2/devices/{device_id}/properties`. This address uniquely identifies the fixture
+        on the PLC bus.

--- a/transformer/schemas.yaml
+++ b/transformer/schemas.yaml
@@ -36,12 +36,13 @@ Transformer:
       example: 60
       description: Maximum number of PLC fixtures supported by this transformer
     current_ma:
-      type: integer
+      type: integer or null
       readOnly: true
       example: 2400
       description: |
         Current total current draw across all taps in milliamps.
         Updated continuously during operation.
+        Null in the case of failure to communicate with the current sensor
     current_limit_yellow_ma:
       type: integer
       example: 5000

--- a/transformer/schemas.yaml
+++ b/transformer/schemas.yaml
@@ -109,12 +109,24 @@ Transformer:
         Only present if commissioning process failed.
     commission_device_info:
       type: object
+      properties:
+        name:
+          type: "string"
+          examples:
+            - "Light 1"
+        location:
+          type: "string"
+          examples:
+            - "My Room"
+        type:
+          type: "string"
+          examples:
+            - "LT"
+        subtype:
+          type: "string"
+          examples:
+            - "GE"
       readOnly: false
-      example: 
-        name: "Light 1"
-        location: "My Room"
-        type: "LT"
-        subtype: "GE"
       description: |
         Device infos for next successfully commissioned device.
         If not fulfilled prior to `commission_mode=true` the firmware will assign default names based on the ID assigned.

--- a/transformer/schemas.yaml
+++ b/transformer/schemas.yaml
@@ -112,20 +112,16 @@ Transformer:
       properties:
         name:
           type: string
-          examples:
-            - "Light 1"
+          example: "Light 1"
         location:
           type: string
-          examples:
-            - "My Room"
+          example: "My Room"
         type:
           type: string
-          examples:
-            - "LT"
+          example: "LT"
         subtype:
           type: string
-          examples:
-            - "GE"
+          example: "GE"
       readOnly: false
       description: |
         Device infos for next successfully commissioned device.

--- a/transformer/schemas.yaml
+++ b/transformer/schemas.yaml
@@ -60,15 +60,15 @@ Transformer:
       type: string
       nullable: true
       readOnly: true
-      enum: [null, "overload_yellow", "overload_red", "overload_hard"]
+      enum: [null, "overload_warning", "overload_shutdown", "overload_short"]
       example: null
       description: |
         Current fault condition:
 
         - `null`: No fault, normal operation
-        - `overload_yellow`: Approaching current limit (soft warning)
-        - `overload_red`: Over current limit, taps have shut down
-        - `overload_hard`: Hard fault detected (likely short circuit)
+        - `overload_warning`: Approaching current limit (soft warning)
+        - `overload_shutdown`: Over current limit, taps have shut down
+        - `overload_short`: Hard fault detected (likely short circuit)
     commission_mode:
       type: boolean
       example: false

--- a/transformer/schemas.yaml
+++ b/transformer/schemas.yaml
@@ -111,19 +111,19 @@ Transformer:
       type: object
       properties:
         name:
-          type: "string"
+          type: string
           examples:
             - "Light 1"
         location:
-          type: "string"
+          type: string
           examples:
             - "My Room"
         type:
-          type: "string"
+          type: string
           examples:
             - "LT"
         subtype:
-          type: "string"
+          type: string
           examples:
             - "GE"
       readOnly: false

--- a/transformer/schemas.yaml
+++ b/transformer/schemas.yaml
@@ -79,73 +79,31 @@ Transformer:
         - Mode auto-expires after `commission_timeout_ms`
 
         Used during fixture pairing and testing workflow.
-    commission_timeout_ms:
-      type: integer
-      example: 300000
-      description: |
-        Auto-expire timeout for commission_mode in milliseconds.
-        Default: 300000 (5 minutes)
-
-        After this duration, commission_mode automatically reverts to false
-        and normal tap operation resumes.
     commission_remaining_ms:
       type: integer
       readOnly: true
-      example: 0
+      example: 30000
       description: |
         Milliseconds remaining before commission_mode automatically disables.
         Returns 0 when commission_mode is false.
-    auto_detect_start:
-      type: boolean
-      example: false
-      description: |
-        Trigger auto-detection of fixture capabilities.
-
-        PATCH to `true` to start auto-detection process.
-        Requires `commission_mode` to be `true`.
-
-        The transformer will analyze the fixture connected to the commissioning
-        port and attempt to determine its capabilities and current draw.
-    auto_detect_busy:
-      type: boolean
-      readOnly: true
-      example: false
-      description: |
-        Indicates whether auto-detection is currently running.
-        When `true`, detection is in progress. When `false`, detection
-        has completed or has not been started.
-    detected_capability:
-      type: string
-      nullable: true
-      readOnly: true
-      enum: [null, "dimmable", "cct", "rgb", "rgbw", "rgbww"]
-      example: "rgbw"
-      description: |
-        Auto-detected fixture capability from most recent detection cycle.
-
-        - `null`: No fixture detected or detection not run
-        - `dimmable`: Dimmable white only
-        - `cct`: Tunable white (cool/warm)
-        - `rgb`: RGB color
-        - `rgbw`: RGB + warm white
-        - `rgbww`: RGB + warm white + cool white (5 channel)
-
-        This is a suggestion only. User may override during commissioning.
-    detected_current_ma:
-      type: integer
-      nullable: true
-      readOnly: true
-      example: 180
-      description: |
-        Detected current draw in milliamps from most recent auto-detection.
-        Returns `null` if no detection has been performed or no fixture detected.
-    next_available_device_id:
+    commission_device_id:
       type: integer
       readOnly: true
       example: 13
       description: |
-        Next available device ID for commissioning a new PLC fixture.
+        Device ID of newly created PLC fixture.
         Range: 1-60
+        Error: -1
 
-        This is the device ID that will be assigned when the next fixture
-        is successfully commissioned via POST to /v2/devices.
+        App can then test fixture by using /v2/devices/{commission_device_id}
+
+        Present whenever commission_mode is false.
+    commission_error_msg:
+      type: string
+      readOnly: true
+      example: No fixture detected
+      description: |
+        Brief user-readable message 
+
+        Only present if commissioning process failed.
+

--- a/transformer/schemas.yaml
+++ b/transformer/schemas.yaml
@@ -107,4 +107,15 @@ Transformer:
         Brief user-readable message 
 
         Only present if commissioning process failed.
-
+    commission_device_info:
+    type: object
+      readOnly: false
+      example: 
+        name: "Light 1"
+        location: "My Room"
+        type: "LT"
+        subtype: "GE"
+      description: |
+        Device infos for next successfully commissioned device.
+        If not fulfilled prior to `commission_mode=true` the firmware will assign default names based on the ID assigned.
+        After successfully new device is commissioned, the `commission_device_info` will be reset.

--- a/transformer/schemas.yaml
+++ b/transformer/schemas.yaml
@@ -108,7 +108,7 @@ Transformer:
 
         Only present if commissioning process failed.
     commission_device_info:
-    type: object
+      type: object
       readOnly: false
       example: 
         name: "Light 1"

--- a/transformer/schemas.yaml
+++ b/transformer/schemas.yaml
@@ -43,19 +43,19 @@ Transformer:
         Current total current draw across all taps in milliamps.
         Updated continuously during operation.
         Null in the case of failure to communicate with the current sensor
-    current_limit_yellow_ma:
+    cur_limit_warning_ma:
       type: integer
       example: 5000
       description: |
         Soft current limit threshold in milliamps.
-        When exceeded, fault status changes to "overload_yellow" as a warning.
+        When exceeded, fault status changes to "overload_warning" as a warning.
         System continues to operate.
-    current_limit_red_ma:
+    cur_limit_shutdown_ma:
       type: integer
       example: 6000
       description: |
         Hard current limit threshold in milliamps.
-        When exceeded, taps shut down and fault status changes to "overload_red".
+        When exceeded, taps shut down and fault status changes to "overload_shutdown".
     fault:
       type: string
       nullable: true

--- a/transformer/schemas.yaml
+++ b/transformer/schemas.yaml
@@ -43,6 +43,16 @@ Transformer:
         Current total current draw across all taps in milliamps.
         Updated continuously during operation.
         Null in the case of failure to communicate with the current sensor
+    power_w:
+      type: integer
+      nullable: true
+      readOnly: true
+      example: 76
+      description: |
+        Live active power draw in watts.
+        Updated continuously from the BL0942 energy metering IC (~500ms).
+        Returns 0 when all taps are off or no load is present.
+        Null in the case of failure to communicate with the current sensor.
     cur_limit_warning_ma:
       type: integer
       example: 5000
@@ -69,6 +79,18 @@ Transformer:
         - `overload_warning`: Approaching current limit (soft warning)
         - `overload_shutdown`: Over current limit, taps have shut down
         - `overload_short`: Hard fault detected (likely short circuit)
+    fault_power_w:
+      type: integer
+      nullable: true
+      readOnly: true
+      example: 310
+      description: |
+        Power draw in watts at the moment a latched fault occurred.
+
+        - `null` when no latched fault is active (including during overload_warning)
+        - Set when fault transitions to `overload_shutdown` or `overload_short`
+        - Persists even after current drops (fault is latched)
+        - Cleared when fault is reset via `fault_reset` or physical button
     fault_reset:
       type: boolean
       example: false

--- a/transformer/schemas.yaml
+++ b/transformer/schemas.yaml
@@ -69,6 +69,16 @@ Transformer:
         - `overload_warning`: Approaching current limit (soft warning)
         - `overload_shutdown`: Over current limit, taps have shut down
         - `overload_short`: Hard fault detected (likely short circuit)
+    fault_reset:
+      type: boolean
+      example: false
+      description: |
+        Write-only field to clear a latched fault condition.
+
+        Set to `true` via PATCH to reset a fault (overload_shutdown or overload_short).
+        Returns 400 if no resettable fault is active.
+
+        Always returns `false` in GET responses.
     commission_mode:
       type: boolean
       example: false

--- a/transformer/schemas.yaml
+++ b/transformer/schemas.yaml
@@ -112,18 +112,54 @@ Transformer:
       properties:
         name:
           type: string
-          example: "Light 1"
+          example: "My Fixture 2"
+          description: |
+            Name for the next commissioned device.
+
+            - If set via PATCH, this custom name will be used
+            - If not set, defaults to "My Fixture {N}" where N is the next available device slot (1-60)
+            - After successful commissioning, this field resets to the default pattern
         location:
           type: string
           example: "My Room"
+          description: |
+            Location for the next commissioned device.
+
+            - If set via PATCH, this custom location will be used
+            - If not set, defaults to "My Room"
         type:
           type: string
           example: "LT"
+          description: |
+            Device type code for the next commissioned device.
+
+            - Only "LT" type is supported for transformers
         subtype:
           type: string
           example: "GE"
+          description: |
+            Device subtype code for the next commissioned device.
+
+            - If set via PATCH, this custom subtype will be used
+            - If not set, defaults to "GE" (Generic)
       readOnly: false
       description: |
-        Device infos for next successfully commissioned device.
-        If not fulfilled prior to `commission_mode=true` the firmware will assign default names based on the ID assigned.
-        After successfully new device is commissioned, the `commission_device_info` will be reset.
+        Metadata for the next device to be commissioned. These values can be pre-set
+        via PATCH to customize the new device before commissioning, or left unset to
+        use intelligent defaults.
+
+        **Dynamic Default Behavior:**
+
+        - `name`: Defaults to "My Fixture {N}" where N is the next available device slot
+          - Example: If devices 1, 3, 4 exist, the default name will be "My Fixture 2"
+          - This ensures unique, predictable device names during commissioning
+        - `location`: Defaults to "My Room"
+        - `type`: Defaults to "LT" (Light)
+        - `subtype`: Defaults to "GE" (Generic)
+
+        **Workflow:**
+
+        1. GET /v2/transformer to see current default values (including next slot number)
+        2. Optionally PATCH /v2/transformer with custom commission_device_info
+        3. PATCH commission_mode=true to start commissioning
+        4. After commissioning succeeds, commission_device_info resets to defaults


### PR DESCRIPTION
## Summary

Adds comprehensive REST API endpoint for PLC transformer control supporting both smart addressable fixtures and legacy relay-switched taps.

## Key Features

- **Device ID Scheme**: PLC fixtures (1-60), Legacy taps (1001-1003)
- **Tap Configuration**: Configure each of 3 taps as legacy or PLC mode
- **Current Monitoring**: Real-time current sensing with yellow/red thresholds
- **Fault Detection**: Overload detection with graduated fault levels
- **Commissioning Workflow**: Safe commissioning mode with auto-detection
- **Auto-Detection**: Automatic fixture capability detection

## API Endpoints

### `GET /v2/transformer`
Returns transformer status including:
- Tap mode configuration
- PLC fixture count
- Current draw and limits
- Fault status
- Commissioning state
- Auto-detection results

### `PATCH /v2/transformer`
Update configuration:
- Tap modes
- Current limits
- Commissioning mode
- Trigger auto-detection

### `DELETE /v2/transformer`
Reset to factory defaults

## Files Changed

- `transformer/schemas.yaml` - Transformer schema definition
- `transformer/paths.yaml` - Endpoint definitions
- `local/paths.yaml` - Register transformer endpoint
- `local.yaml` - Add Transformer tag group

## Testing Notes

This is API documentation only. Firmware implementation required for full functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)