### PR TITLE
Add OpenRaiseRetract feature with Raise/Lower/Retract/Extend actions

### DIFF
--- a/common/info.yaml
+++ b/common/info.yaml
@@ -1463,14 +1463,24 @@ description: |
 
   NOTE: The heat level is remembered on TurnOff and restored on TurnOn.
 
-  ## Open
+  ## OpenRaiseRetract
 
-  The Open feature is used to describe a device that can be opened and closed.
-  Common use cases are motorized shades and garage doors.
+  The OpenRaiseRetract feature is used to describe a device that can be opened and closed,
+  raised and lowered, or retracted and extended.
+  Common use cases are motorized shades, awnings, and garage doors.
 
   ### Properties
 
-  (none)
+   - **open_raises**: (boolean) When true (default), Open() raises the device and Close() lowers it.
+     When false, Open() lowers the device and Close() raises it.
+     Defaults to `true` for most devices.
+     Defaults to `false` for AWNING subtype and Top-Down roller shades.
+
+   - **open_retracts**: (boolean) When true (default), Open() retracts the device and Close() extends it.
+     When false, Open() extends the device and Close() retracts it.
+     Defaults to `true` for most devices.
+     Defaults to `false` for AWNING subtype.
+     Defaults to `true` for Top-Down roller shades.
 
   ### State Variables
 
@@ -1480,20 +1490,30 @@ description: |
 
   - **Open()**: Open the device.
   - **Close()**: Close the device.
-  - **ToggleOpen()**: Close the device if it's open, open it if it's closed
+  - **ToggleOpen()**: Close the device if it's open, open it if it's closed.
+  - **Raise()**: Raise the device. Equivalent to Open() if `open_raises` is true, otherwise equivalent to Close().
+  - **Lower()**: Lower the device. Equivalent to Close() if `open_raises` is true, otherwise equivalent to Open().
+  - **Retract()**: Retract the device. Equivalent to Open() if `open_retracts` is true, otherwise equivalent to Close().
+  - **Extend()**: Extend the device. Equivalent to Close() if `open_retracts` is true, otherwise equivalent to Open().
 
   ### Notes
+
+  The three action pairs serve different integration needs:
+
+  - **Raise/Lower**: Map to up/down buttons on remotes and wall switches.
+  - **Open/Close**: Support voice assistants and interfaces using "open"/"close" intents.
+  - **Retract/Extend**: Align with Position semantics (0 = retracted, 100 = extended); included for completeness.
 
   If your remote has a discrete stopping command, consider using the **Hold()** action
   to stop the motion of the device.
 
   ## Position
 
-  The Position feature is used to describe a device that can be opened
-  to a specific position as a percentage.
+  The Position feature is used to describe a device that can be set
+  to a specific position as a percentage of extension.
   The common use case is motorized shades.
 
-  The Position feature requires the Open feature.
+  The Position feature requires the OpenRaiseRetract feature.
 
   ### Properties
 
@@ -1501,15 +1521,13 @@ description: |
 
   ### State Variables
 
-   - **position**: (integer) value from 0 to 100: 0 = open, 100 = closed.
+   - **position**: (integer) value from 0 to 100: 0 = retracted, 100 = extended.
 
   ### Actions
 
-  - **SetPosition(position)**: Set device to specified position percentage.
-  - **IncreasePosition(amount)**: Close the device by the specified percentage
-   of the full range.
-  - **DecreasePosition(amount)**: Open the device by the specified percentage
-   of the full range.
+  - **SetPosition(position)**: Set device to specified position percentage (0 = retracted, 100 = extended).
+  - **IncreasePosition(amount)**: Extend the device by the specified percentage of the full range.
+  - **DecreasePosition(amount)**: Retract the device by the specified percentage of the full range.
 
   ### Notes
 

--- a/common/info.yaml
+++ b/common/info.yaml
@@ -1591,9 +1591,15 @@ description: |
 
     - **SetUpperRailPosition(position)**: Set the position of the upper rail.
     - **SetLowerRailPosition(position)**: Set the position of the lower rail.
+    - **RaiseUpperRail()**: Raise the upper rail.
+    - **LowerUpperRail()**: Lower the upper rail.
+    - **RaiseLowerRail()**: Raise the lower rail.
+    - **LowerLowerRail()**: Lower the lower rail.
 
-    The SetPosition action will set the upper rail to 0% and the lower rail to the
-    requested position.
+    TDBU shades also have the Position feature. OpenRaiseRetract and Position actions
+    default to bottom-up (lower rail) semantics: SetPosition controls the lower rail,
+    Raise/Lower/Open/Close operate on the lower rail, and the upper rail is driven
+    all the way up.
 
     Note: if an action requests a position that is not possible due to the
     position of the other rail, the Bond Bridge will adjust the other rail

--- a/groups/schemas.yaml
+++ b/groups/schemas.yaml
@@ -46,6 +46,10 @@ Group:
       example:
         - "Open"
         - "Close"
+        - "Raise"
+        - "Lower"
+        - "Retract"
+        - "Extend"
         - "Preset"
       description: |
         The list of available Actions on the Group.

--- a/skeds/channel-paths.yaml
+++ b/skeds/channel-paths.yaml
@@ -71,12 +71,11 @@ Post:
        - POSTed `mark` is `dawn`, `dusk`, `sunrise`, or `sunset`, but `sys/time.grid` or `sys/time.tz` is `null`
 
     Available actions depend on the channel type. Common actions:
-    - Motorized Shades (MS): Raise, Lower, Retract, Extend, Stop, SetPosition, Preset
+    - Motorized Shades (MS): Raise, Lower, Stop, SetPosition, Preset
     - Lights (LT): TurnLightOn, TurnLightOff, SetBrightness
 
     Note: Open and Close actions are not available for channel schedules,
-    as Mate does not track the `open_raises` and `open_retracts` properties
-    that determine the mapping between Raise/Lower/Retract/Extend and Open/Close
+    as Mate does not track the inversion between Raise/Lower and Open/Close
     for different shade types (e.g., awnings).
 
   tags:

--- a/skeds/channel-paths.yaml
+++ b/skeds/channel-paths.yaml
@@ -71,11 +71,12 @@ Post:
        - POSTed `mark` is `dawn`, `dusk`, `sunrise`, or `sunset`, but `sys/time.grid` or `sys/time.tz` is `null`
 
     Available actions depend on the channel type. Common actions:
-    - Motorized Shades (MS): Raise, Lower, Stop, SetPosition, Preset
+    - Motorized Shades (MS): Raise, Lower, Retract, Extend, Stop, SetPosition, Preset
     - Lights (LT): TurnLightOn, TurnLightOff, SetBrightness
 
     Note: Open and Close actions are not available for channel schedules,
-    as Mate does not track the inversion between Raise/Lower and Open/Close
+    as Mate does not track the `open_raises` and `open_retracts` properties
+    that determine the mapping between Raise/Lower/Retract/Extend and Open/Close
     for different shade types (e.g., awnings).
 
   tags:


### PR DESCRIPTION
## Summary

- Rename Open feature to OpenRaiseRetract with new `open_raises` and `open_retracts` properties
- Add Raise, Lower, Retract, Extend actions mapped via properties for consistent physical controls
- Update Position feature semantics to 0=retracted, 100=extended
- Add TDBU rail-specific actions: RaiseUpperRail, LowerUpperRail, RaiseLowerRail, LowerLowerRail

This is a pre-requisite for the forthcoming automatic linking feature.

## Details

**New properties** on OpenRaiseRetract:
- `open_raises`: defaults true; false for AWNING and Top-Down shades
- `open_retracts`: defaults true; false for AWNING

**Action use cases:**
- Raise/Lower: Map to up/down buttons on remotes and wall switches
- Open/Close: Support voice assistants and interfaces using "open"/"close" intents
- Retract/Extend: Align with Position semantics; included for completeness

## Test plan

- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)